### PR TITLE
Dispatch-based metadata model + parallel-by-default execution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.9.1" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="1.9.1" />
     <PackageVersion Include="Serde.Xml" Version="0.3.2" />
+    <PackageVersion Include="StaticCS" Version="0.3.1" />
     <PackageVersion Include="StaticCs.Collections" Version="1.1.0" />
     <PackageVersion Include="StaticCS.IndentingBuilder" Version="0.3.0" />
     <PackageVersion Include="xunit.v3" Version="3.1.0" />

--- a/README.md
+++ b/README.md
@@ -2,22 +2,18 @@
 
 [![CI](https://github.com/agocke/uxunit/actions/workflows/ci.yml/badge.svg)](https://github.com/agocke/uxunit/actions/workflows/ci.yml)
 
-A modern, source-generated replacement for xUnit that provides compile-time test discovery, enhanced performance, and improved developer experience.
+A modern, source-generated replacement for xUnit that provides compile-time test discovery and simple functionality.
 
 ## Overview
 
-UXUnit leverages C# source generators to create a high-performance testing framework that eliminates runtime reflection and provides compile-time test validation.
+UXUnit leverages C# source generators to create a small, simple testing framework that eliminates runtime reflection and provides compile-time test validation. It aims to be an easy, drop-in replacement for the core of xUnit rather than a large, feature-rich framework.
 
 ## Key Features
 
 - **Source-Generated Test Discovery**: Tests are discovered at compile time, eliminating runtime reflection overhead
 - **Compile-Time Validation**: Test method signatures and attributes are validated during compilation
-- **Zero Runtime Dependencies**: No heavy framework dependencies at runtime
-- **Enhanced Performance**: Significantly faster test execution through pre-compiled test runners
 - **Rich Assertion Library**: Uses `xunit.assert` for compatibility and comprehensive assertion capabilities
 - **Parameterized Tests**: Full support for data-driven tests with source generators
-- **Parallel Execution**: Built-in support for parallel test execution with fine-grained control
-- **XUnit Compatibility**: Designed for easy migration from XUnit with shared assertion library
 
 ## Documentation
 
@@ -30,14 +26,14 @@ UXUnit leverages C# source generators to create a high-performance testing frame
 
 ```
 ├── src/
-│   ├── UXUnit.Core/           # Core framework types and interfaces
+│   ├── UXUnit.Core/           # Core framework types and attributes
 │   ├── UXUnit.Generators/     # Source generators
 │   └── UXUnit.Runtime/        # Test runner and execution engine
 ├── test/
-│   ├── Assets/XUnitCompatibility/ # XUnit compatibility demonstration
-│   ├── UXUnit.Core.Tests/
+│   ├── Assets/                # Compatibility assets (UXUnitCompat, XUnitCompat, shared)
+│   ├── UXUnit.CompatibilityTests/
 │   ├── UXUnit.Generators.Tests/
-│   └── UXUnit.Integration.Tests/
+│   └── UXUnit.Runtime.Tests/
 └── docs/                      # Documentation
 ```
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -24,7 +24,7 @@ public sealed class TestAssemblyMetadata
 
 public sealed class AssemblyConfiguration
 {
-    public bool ParallelExecution { get; init; } = true;
+    public ParallelMode Mode { get; init; } = ParallelMode.Tests;
     public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount;
     public int DefaultTimeoutMs { get; init; } = 0; // No timeout
     public bool StopOnFirstFailure { get; init; } = false;
@@ -44,27 +44,11 @@ public sealed class TestClassMetadata
     public string? Category { get; init; }
     public bool Skip { get; init; }
     public string? SkipReason { get; init; }
-    public ParallelConfiguration ParallelConfig { get; init; } = new();
     public IReadOnlyList<TestMethodMetadata> TestMethods { get; init; } = Array.Empty<TestMethodMetadata>();
     public IReadOnlyList<LifecycleMethodMetadata> SetupMethods { get; init; } = Array.Empty<LifecycleMethodMetadata>();
     public IReadOnlyList<LifecycleMethodMetadata> CleanupMethods { get; init; } = Array.Empty<LifecycleMethodMetadata>();
-    public IReadOnlyList<LifecycleMethodMetadata> ClassSetupMethods { get; init; } = Array.Empty<LifecycleMethodMetadata>();
-    public IReadOnlyList<LifecycleMethodMetadata> ClassCleanupMethods { get; init; } = Array.Empty<LifecycleMethodMetadata>();
     public IReadOnlyDictionary<string, object?> Properties { get; init; } = new Dictionary<string, object?>();
     public TypeInfo ClassType { get; init; } = default!;
-}
-
-public sealed class ParallelConfiguration
-{
-    public ParallelExecution Execution { get; init; } = ParallelExecution.Enabled;
-    public string? Group { get; init; }
-}
-
-public enum ParallelExecution
-{
-    Enabled,
-    Disabled,
-    Required
 }
 ```
 
@@ -81,7 +65,6 @@ public sealed class TestMethodMetadata
     public string? SkipReason { get; init; }
     public int TimeoutMs { get; init; } = 0;
     public Type? ExpectedExceptionType { get; init; }
-    public ParallelConfiguration ParallelConfig { get; init; } = new();
     public RetryConfiguration RetryConfig { get; init; } = new();
     public IReadOnlyList<TestCaseMetadata> TestCases { get; init; } = Array.Empty<TestCaseMetadata>();
     public IReadOnlyList<CustomAttributeMetadata> CustomAttributes { get; init; } = Array.Empty<CustomAttributeMetadata>();
@@ -130,9 +113,7 @@ public sealed class LifecycleMethodMetadata
 public enum LifecycleMethodType
 {
     Setup,
-    Cleanup,
-    ClassSetup,
-    ClassCleanup
+    Cleanup
 }
 ```
 
@@ -382,17 +363,11 @@ public sealed class TestRunConfiguration
 {
     public TestAssemblyMetadata Assembly { get; init; } = default!;
     public TestFilter Filter { get; init; } = TestFilter.All;
-    public ParallelExecutionSettings ParallelSettings { get; init; } = new();
+    public ParallelMode Mode { get; init; } = ParallelMode.Tests;
+    public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount;
     public ITestOutput Output { get; init; } = NullTestOutput.Instance;
     public bool StopOnFirstFailure { get; init; } = false;
     public TimeSpan? GlobalTimeout { get; init; }
-}
-
-public sealed class ParallelExecutionSettings
-{
-    public bool Enabled { get; init; } = true;
-    public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount;
-    public TaskScheduler? TaskScheduler { get; init; }
 }
 ```
 

--- a/docs/design-core.md
+++ b/docs/design-core.md
@@ -116,20 +116,11 @@ public sealed class TestCaseMetadata
 
 ### Attributes
 
-Attributes are used to mark test classes and methods. These are recognized by the source generator.
+Attributes are used to mark test methods and data. Test classes are discovered automatically from methods marked with test attributes.
 
 #### Test Marking Attributes
 
 ```csharp
-[AttributeUsage(AttributeTargets.Class)]
-public sealed class TestClassAttribute : Attribute
-{
-    public string? DisplayName { get; set; }
-    public string? Category { get; set; }
-    public bool Skip { get; set; }
-    public string? SkipReason { get; set; }
-}
-
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class TestAttribute : Attribute
 {
@@ -168,12 +159,6 @@ public sealed class SetupAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class CleanupAttribute : Attribute { }
-
-[AttributeUsage(AttributeTargets.Method)]
-public sealed class ClassSetupAttribute : Attribute { }
-
-[AttributeUsage(AttributeTargets.Method)]
-public sealed class ClassCleanupAttribute : Attribute { }
 ```
 
 ### Interfaces
@@ -223,13 +208,6 @@ public interface ITestMethodAttribute
     void OnBeforeTest(ITestContext context);
     void OnAfterTest(ITestContext context, TestResult result);
 }
-
-public interface ITestClassAttribute
-{
-    void OnBeforeClass(ITestContext context);
-    void OnAfterClass(ITestContext context, TestResult[] results);
-}
-
 public interface ITestDataSource
 {
     IEnumerable<object?[]> GetTestData(TestMethodMetadata methodMetadata);

--- a/docs/design-generator.md
+++ b/docs/design-generator.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-UXUnit.Generators is a Roslyn source generator that analyzes test code at compile time and generates optimized test execution code. This eliminates runtime reflection, enables compile-time validation, and produces highly optimized test runners.
+UXUnit.Generators is a Roslyn source generator that analyzes test code at compile time and generates test execution code. This eliminates runtime reflection, enables compile-time validation, and produces simple, direct test runners.
 
 ## Design Principles
 
@@ -40,7 +40,7 @@ class TestClassSyntaxReceiver : ISyntaxReceiver
 
     public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
     {
-        // Find classes with [TestClass], [Fact], [Theory] attributes
+        // Find classes containing methods marked [Fact] or [Theory]
         if (syntaxNode is ClassDeclarationSyntax classDecl)
         {
             if (HasTestAttributes(classDecl))
@@ -392,7 +392,6 @@ The generator itself has comprehensive tests:
 public void GeneratesCorrectCode_ForSimpleTest()
 {
     var source = @"
-        [TestClass]
         public class MyTests
         {
             [Fact]

--- a/docs/design-runtime.md
+++ b/docs/design-runtime.md
@@ -9,7 +9,7 @@ UXUnit.Runtime is the execution engine that runs generated test code. It's **not
 1. **Simple Function**: Transform test metadata into test results
 2. **No Abstractions**: No ITestRunner, ITestClassRunner interfaces
 3. **Separation of Concerns**: Execution is separate from presentation
-4. **Performance**: Minimal overhead, efficient parallel execution
+4. **Lightweight**: Minimal overhead, efficient parallel execution
 5. **Stateless**: No global state, pure functional approach where possible
 
 ## Core Architecture
@@ -54,20 +54,19 @@ public static class TestExecutionEngine
     {
         var allTests = CollectAllTests(testClasses);
 
-        if (options.ParallelExecution)
+        return options.Mode switch
         {
-            return await ExecuteInParallelAsync(allTests, options, cancellationToken);
-        }
-        else
-        {
-            return await ExecuteSequentiallyAsync(allTests, options, cancellationToken);
-        }
+            ParallelMode.None => await ExecuteSequentiallyAsync(allTests, options, cancellationToken),
+            ParallelMode.Classes => await ExecuteClassesInParallelAsync(allTests, options, cancellationToken),
+            _ => await ExecuteTestsInParallelAsync(allTests, options, cancellationToken),
+        };
     }
 
     private static List<TestDescriptor> CollectAllTests(
         IReadOnlyList<TestClassMetadata> testClasses)
     {
-        // Flatten all test methods from all classes
+        // Flatten all test methods from all classes, then randomly permute them
+        // on each run to surface accidental ordering dependencies.
         // Each TestDescriptor contains:
         // - Metadata (name, timeout, etc.)
         // - Execution delegate (Func<CancellationToken, Task<TestResult>>)
@@ -92,13 +91,19 @@ public static class TestExecutionEngine
 Configuration for test execution:
 
 ```csharp
+public enum ParallelMode
+{
+    None,     // everything runs sequentially
+    Classes,  // classes run in parallel; tests within a class run sequentially
+    Tests,    // individual tests run in parallel, regardless of class (default)
+}
+
 public sealed class TestExecutionOptions
 {
-    public bool ParallelExecution { get; init; } = true;
+    public ParallelMode Mode { get; init; } = ParallelMode.Tests;
     public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount;
     public bool StopOnFirstFailure { get; init; } = false;
     public TimeSpan? GlobalTimeout { get; init; }
-    public ITestOutputSink? OutputSink { get; init; }
 }
 ```
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,15 +2,15 @@
 
 ## Vision
 
-UXUnit is a next-generation unit testing framework for .NET that leverages source generators to provide compile-time test discovery, validation, and code generation. The framework aims to deliver superior performance, better developer experience, and enhanced reliability compared to traditional reflection-based testing frameworks.
+UXUnit is a small, simple unit testing framework for .NET that leverages source generators to provide compile-time test discovery, validation, and code generation. It aims to be an easy, drop-in replacement for the core of xUnit — covering the common testing scenarios without the size and complexity of a full-featured framework.
 
 ## Design Goals
 
 ### Primary Goals
-- **Performance**: Eliminate runtime reflection overhead through compile-time code generation
-- **Developer Experience**: Provide rich tooling support, clear error messages, and intuitive APIs
+- **Simplicity**: A small, focused framework with minimal boilerplate and configuration
+- **xUnit Familiarity**: Support the common xUnit patterns (`[Fact]`, `[Theory]`, `[InlineData]`) for an easy migration
 - **Reliability**: Catch test configuration errors at compile time rather than runtime
-- **Simplicity**: Minimize boilerplate code and configuration complexity
+- **No Runtime Reflection**: Discover and run tests via compile-time code generation
 - **Clean Architecture**: No unnecessary abstraction layers
 
 ### Non-Goals
@@ -74,13 +74,9 @@ See [Generator Design Document](./design-generator.md) for details.
 
 See [Runtime Design Document](./design-runtime.md) for details.
 
-#### UXUnit.Assertions
-**Purpose**: Assertion library
-**Fluent API for test assertions**
+#### Assertions
 
-- Equality, comparison, collection assertions
-- Exception assertions
-- Custom assertion extensibility
+UXUnit does not ship its own assertion library. Tests use `xunit.assert`, which keeps the framework small and eases migration from xUnit.
 
 ## Key Design Principles
 
@@ -124,7 +120,6 @@ instance.MyTestMethod();
 
 **User writes**:
 ```csharp
-[TestClass]
 public class CalculatorTests
 {
     [Fact]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,7 +20,7 @@ Add the following package references to your test project:
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="UXUnit.Assertions" Version="1.0.0" />
+    <PackageReference Include="xunit.v3.assert" Version="3.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
@@ -37,10 +37,7 @@ Add common usings to a `GlobalUsings.cs` file:
 
 ```csharp
 global using UXUnit;
-global using UXUnit.Assertions;
-global using static UXUnit.Assert;
-```
-global using static UXUnit.Assert;
+global using static Xunit.Assert;
 ```
 
 ## Your First Test

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,10 +8,9 @@ This document provides a comprehensive specification of the UXUnit testing frame
 
 ### Test Classes
 
-A test class is a class marked with the `[TestClass]` attribute that contains one or more test methods.
+A test class is a plain class containing one or more methods marked with `[Fact]` or `[Theory]`. Test classes are discovered automatically from those methods.
 
 #### Requirements
-- Must be marked with `[TestClass]` attribute
 - Must be public or internal
 - Must have a parameterless constructor
 - May contain setup and cleanup methods
@@ -19,16 +18,9 @@ A test class is a class marked with the `[TestClass]` attribute that contains on
 
 #### Example
 ```csharp
-[TestClass]
 public class CalculatorTests
 {
     private Calculator _calculator;
-
-    [ClassSetup]
-    public void InitializeClass()
-    {
-        // Run once before all tests in the class
-    }
 
     [Setup]
     public void Setup()
@@ -47,12 +39,6 @@ public class CalculatorTests
     public void Cleanup()
     {
         _calculator?.Dispose();
-    }
-
-    [ClassCleanup]
-    public void CleanupClass()
-    {
-        // Run once after all tests in the class
     }
 }
 ```
@@ -80,26 +66,6 @@ A test method is a method marked with the `[Test]` attribute within a test class
 ## Attributes
 
 ### Core Attributes
-
-#### `[TestClass]`
-Marks a class as containing test methods.
-
-```csharp
-[AttributeUsage(AttributeTargets.Class)]
-public class TestClassAttribute : Attribute
-{
-    public string? DisplayName { get; set; }
-    public string? Category { get; set; }
-    public bool Skip { get; set; }
-    public string? SkipReason { get; set; }
-}
-```
-
-**Properties:**
-- `DisplayName`: Custom display name for the test class
-- `Category`: Category for grouping tests
-- `Skip`: Whether to skip all tests in this class
-- `SkipReason`: Reason for skipping (required if Skip = true)
 
 #### `[Test]`
 Marks a method as a test case.
@@ -165,17 +131,10 @@ public class SetupAttribute : Attribute { }
 
 [AttributeUsage(AttributeTargets.Method)]
 public class CleanupAttribute : Attribute { }
-
-[AttributeUsage(AttributeTargets.Method)]
-public class ClassSetupAttribute : Attribute { }
-
-[AttributeUsage(AttributeTargets.Method)]
-public class ClassCleanupAttribute : Attribute { }
 ```
 
 **Requirements:**
 - Setup/Cleanup methods must be public and return void or Task
-- ClassSetup/ClassCleanup methods must be static
 - Multiple setup/cleanup methods are allowed (execution order is undefined)
 
 ### Advanced Attributes
@@ -212,25 +171,6 @@ public class RetryAttribute : Attribute
         if (maxAttempts <= 0) throw new ArgumentException("MaxAttempts must be positive");
         MaxAttempts = maxAttempts;
     }
-}
-```
-
-#### `[Parallel]`
-Controls parallel execution behavior.
-
-```csharp
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
-public class ParallelAttribute : Attribute
-{
-    public ParallelExecution Execution { get; set; } = ParallelExecution.Enabled;
-    public string? Group { get; set; } // Tests in same group run sequentially
-}
-
-public enum ParallelExecution
-{
-    Enabled,    // Can run in parallel with other tests
-    Disabled,   // Must run sequentially
-    Required    // Must run in parallel (fails if not possible)
 }
 ```
 
@@ -387,41 +327,16 @@ public class JsonDataAttribute : Attribute
 
 ### Execution Order
 
-1. **Class Construction**: Test class instance is created
-2. **ClassSetup**: Static class setup methods are called (once per class)
-3. **For each test method**:
+1. **For each test method**:
+   - **Class Construction**: A new test class instance is created
    - **Setup**: Instance setup methods are called
    - **Test Execution**: The test method is invoked
    - **Cleanup**: Instance cleanup methods are called
-4. **ClassCleanup**: Static class cleanup methods are called (once per class)
-5. **Class Disposal**: Test class instance is disposed if it implements IDisposable
+   - **Class Disposal**: The test class instance is disposed if it implements IDisposable
 
 ### Parallel Execution
 
-Tests can run in parallel by default. Control parallel execution using:
-
-```csharp
-// Disable parallel execution for entire class
-[TestClass]
-[Parallel(Execution = ParallelExecution.Disabled)]
-public class SerialTests { }
-
-// Group tests that must run sequentially
-[TestClass]
-public class GroupedTests
-{
-    [Fact]
-    [Parallel(Group = "Database")]
-    public void DatabaseTest1() { }
-
-    [Fact]
-    [Parallel(Group = "Database")]
-    public void DatabaseTest2() { }
-
-    [Fact] // Can run in parallel with any other test
-    public void IndependentTest() { }
-}
-```
+Every test runs in parallel by default, and tests are randomly permuted on each run to surface accidental ordering dependencies. Control this with `TestExecutionOptions.Mode` (`ParallelMode.Tests` by default, or `ParallelMode.Classes` to run classes in parallel while keeping the tests within a class sequential, or `ParallelMode.None` to run everything sequentially) and `TestExecutionOptions.MaxDegreeOfParallelism`.
 
 ### Exception Handling
 
@@ -511,7 +426,7 @@ public void TestWithOutput(ITestContext context)
 
 ```csharp
 [assembly: UXUnitConfiguration(
-    ParallelExecution = true,
+    Mode = ParallelMode.Tests,
     MaxDegreeOfParallelism = 4,
     DefaultTimeout = 30000,
     StopOnFirstFailure = false
@@ -581,7 +496,7 @@ public class DatabaseTestAttribute : Attribute, ITestMethodAttribute
 | `[Theory]` + `[InlineData]` | `[Theory]` + `[InlineData]` |
 | `[ClassData]` | `[TestDataSource]` |
 | `IClassFixture<T>` | Constructor injection |
-| `ICollectionFixture<T>` | `[ClassSetup]`/`[ClassCleanup]` |
+| `ICollectionFixture<T>` | Not supported |
 | `[Skip]` | `Skip = true` property |
 
 ### Code Examples
@@ -610,7 +525,6 @@ public class CalculatorTests
 
 **UXUnit:**
 ```csharp
-[TestClass]
 public class CalculatorTests
 {
     [Fact]

--- a/src/UXUnit.Core/Models.cs
+++ b/src/UXUnit.Core/Models.cs
@@ -52,8 +52,6 @@ public sealed class TestResult
 
     public string? ClassDisplayName { get; init; }
 
-    public required string AssemblyName { get; init; }
-
     public TestStatus Status { get; init; }
 
     public TimeSpan Duration { get; init; }
@@ -78,15 +76,13 @@ public sealed class TestResult
         string testId,
         string testName,
         TimeSpan duration,
-        string className,
-        string assemblyName
+        string className
     ) =>
         new()
         {
             TestId = testId,
             TestName = testName,
             ClassName = className,
-            AssemblyName = assemblyName,
             Status = TestStatus.Passed,
             Duration = duration,
         };
@@ -99,15 +95,13 @@ public sealed class TestResult
         string testName,
         Exception exception,
         TimeSpan duration,
-        string className,
-        string assemblyName
+        string className
     ) =>
         new()
         {
             TestId = testId,
             TestName = testName,
             ClassName = className,
-            AssemblyName = assemblyName,
             Status = TestStatus.Failed,
             Duration = duration,
             ErrorMessage = exception.Message,
@@ -123,15 +117,13 @@ public sealed class TestResult
         string testName,
         string errorMessage,
         string? stackTrace,
-        string className,
-        string assemblyName
+        string className
     ) =>
         new()
         {
             TestId = testId,
             TestName = testName,
             ClassName = className,
-            AssemblyName = assemblyName,
             Status = TestStatus.Failed,
             ErrorMessage = errorMessage,
             StackTrace = stackTrace,
@@ -144,15 +136,13 @@ public sealed class TestResult
         string testId,
         string testName,
         string reason,
-        string className,
-        string assemblyName
+        string className
     ) =>
         new()
         {
             TestId = testId,
             TestName = testName,
             ClassName = className,
-            AssemblyName = assemblyName,
             Status = TestStatus.Skipped,
             SkipReason = reason,
         };
@@ -164,8 +154,6 @@ public sealed class TestResult
 public sealed class TestClassMetadata
 {
     public required string ClassName { get; init; }
-
-    public required string AssemblyName { get; init; }
 
     public string? DisplayName { get; init; }
 

--- a/src/UXUnit.Core/Models.cs
+++ b/src/UXUnit.Core/Models.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using StaticCs;
 
 namespace UXUnit;
 
 /// <summary>
 /// Represents the status of a test execution.
 /// </summary>
+[Closed]
 public enum TestStatus
 {
     /// <summary>
@@ -24,6 +27,11 @@ public enum TestStatus
     /// The test was skipped.
     /// </summary>
     Skipped,
+
+    /// <summary>
+    /// The test was not executed due to a fault in the test infrastructure.
+    /// </summary>
+    Faulted,
 }
 
 /// <summary>
@@ -51,8 +59,6 @@ public sealed class TestResult
     public TimeSpan Duration { get; init; }
 
     public string? ErrorMessage { get; init; }
-
-    public string? ErrorType { get; init; }
 
     public string? StackTrace { get; init; }
 
@@ -105,8 +111,30 @@ public sealed class TestResult
             Status = TestStatus.Failed,
             Duration = duration,
             ErrorMessage = exception.Message,
-            ErrorType = exception.GetType().FullName,
             StackTrace = exception.StackTrace,
+        };
+
+    /// <summary>
+    /// Represents a fault in the test infrastructure, such as an exception thrown during
+    /// test discovery or setup, rather than a failure of the test itself.
+    /// </summary>
+    public static TestResult Fault(
+        string testId,
+        string testName,
+        string errorMessage,
+        string? stackTrace,
+        string className,
+        string assemblyName
+    ) =>
+        new()
+        {
+            TestId = testId,
+            TestName = testName,
+            ClassName = className,
+            AssemblyName = assemblyName,
+            Status = TestStatus.Failed,
+            ErrorMessage = errorMessage,
+            StackTrace = stackTrace,
         };
 
     /// <summary>
@@ -149,6 +177,11 @@ public sealed class TestClassMetadata
 
     public IReadOnlyList<TestMethodMetadata> TestMethods { get; init; } =
         Array.Empty<TestMethodMetadata>();
+
+    public delegate Task DispatchFunc(object? receiver, string methodName, object? theoryArgs);
+
+    public required Func<object?> CreateInstance { get; init; }
+    public required DispatchFunc TestDispatch { get; init; }
 }
 
 /// <summary>
@@ -163,10 +196,6 @@ public abstract class TestMethodMetadata
     private TestMethodMetadata() { }
 
     public required string MethodName { get; init; }
-
-    public string? DisplayName { get; init; }
-
-    public string? Category { get; init; }
 
     public bool Skip { get; init; }
 
@@ -183,11 +212,6 @@ public abstract class TestMethodMetadata
     /// </summary>
     public sealed class Fact : TestMethodMetadata
     {
-        /// <summary>
-        /// Gets the test body delegate for this fact.
-        /// The delegate contains the actual test code.
-        /// </summary>
-        public Func<CancellationToken, Task>? Body { get; init; }
     }
 
     /// <summary>
@@ -196,30 +220,21 @@ public abstract class TestMethodMetadata
     public sealed class Theory : TestMethodMetadata
     {
         /// <summary>
-        /// Gets the test body delegate for this theory.
-        /// The delegate accepts arguments and contains the actual test code.
-        /// </summary>
-        public Func<object?[], CancellationToken, Task>? ParameterizedBody { get; init; }
-
-        /// <summary>
         /// Gets the test cases for this theory.
         /// Each test case provides arguments for one execution of the test.
         /// </summary>
-        public IReadOnlyList<TestCaseMetadata> TestCases { get; init; } =
-            Array.Empty<TestCaseMetadata>();
-    }
+        public IReadOnlyList<TestCaseInfo> TestCases { get; init; } =
+            Array.Empty<TestCaseInfo>();
+
+           }
 }
 
 /// <summary>
 /// Represents metadata for a test case (parameterized test data).
 /// </summary>
-public sealed class TestCaseMetadata
+public readonly struct TestCaseInfo
 {
-    public object?[] Arguments { get; init; } = Array.Empty<object?>();
+    public required object? Arguments { get; init; }
 
-    public string? DisplayName { get; init; }
-
-    public bool Skip { get; init; }
-
-    public string? SkipReason { get; init; }
+    public required string DisplayName { get; init; }
 }

--- a/src/UXUnit.Core/UXUnit.Core.csproj
+++ b/src/UXUnit.Core/UXUnit.Core.csproj
@@ -19,4 +19,11 @@
   <ItemGroup>
     <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StaticCS">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/UXUnit.Generators/TestGenerator.cs
+++ b/src/UXUnit.Generators/TestGenerator.cs
@@ -175,7 +175,6 @@ public sealed class TestGenerator : IIncrementalGenerator
         builder.AppendLine("{");
         builder.Indent();
         builder.AppendLine($"ClassName = \"{className}\",");
-        builder.AppendLine($"AssemblyName = \"{testClass.TestClass.ContainingAssembly.Name}\",");
 
         if (isClassStatic)
         {

--- a/src/UXUnit.Generators/TestGenerator.cs
+++ b/src/UXUnit.Generators/TestGenerator.cs
@@ -167,6 +167,8 @@ public sealed class TestGenerator : IIncrementalGenerator
         TestClassWithMethods testClass)
     {
         var className = testClass.TestClass.ToDisplayString();
+        var fqName = "global::" + className;
+        var isClassStatic = testClass.TestClass.IsStatic;
 
         builder.AppendLine("return ");
         builder.AppendLine("new TestClassMetadata");
@@ -174,6 +176,18 @@ public sealed class TestGenerator : IIncrementalGenerator
         builder.Indent();
         builder.AppendLine($"ClassName = \"{className}\",");
         builder.AppendLine($"AssemblyName = \"{testClass.TestClass.ContainingAssembly.Name}\",");
+
+        if (isClassStatic)
+        {
+            builder.AppendLine("CreateInstance = () => null,");
+        }
+        else
+        {
+            builder.AppendLine($"CreateInstance = () => new {fqName}(),");
+        }
+
+        GenerateDispatch(builder, testClass, fqName);
+
         builder.AppendLine("TestMethods = new TestMethodMetadata[]");
         builder.AppendLine("{");
         builder.Indent();
@@ -196,6 +210,87 @@ public sealed class TestGenerator : IIncrementalGenerator
         builder.AppendLine("};");
     }
 
+    private static void GenerateDispatch(
+        IndentingBuilder builder,
+        TestClassWithMethods testClass,
+        string fqName)
+    {
+        builder.AppendLine("TestDispatch = async (receiver, methodName, theoryArgs) =>");
+        builder.AppendLine("{");
+        builder.Indent();
+        builder.AppendLine("switch (methodName)");
+        builder.AppendLine("{");
+        builder.Indent();
+
+        foreach (var method in testClass.Methods)
+        {
+            builder.AppendLine($"case \"{method.MethodSymbol.Name}\":");
+            builder.AppendLine("{");
+            builder.Indent();
+            GenerateInvocation(builder, method, fqName);
+            builder.AppendLine("break;");
+            builder.Dedent();
+            builder.AppendLine("}");
+        }
+
+        builder.AppendLine("default:");
+        builder.Indent();
+        builder.AppendLine(
+            "throw new global::System.InvalidOperationException(\"Unknown test method: \" + methodName);");
+        builder.Dedent();
+
+        builder.Dedent();
+        builder.AppendLine("}");
+        builder.AppendLine("await global::System.Threading.Tasks.Task.CompletedTask;");
+        builder.Dedent();
+        builder.AppendLine("},");
+    }
+
+    private static void GenerateInvocation(
+        IndentingBuilder builder,
+        TestMethodInfo method,
+        string fqName)
+    {
+        var methodName = method.MethodSymbol.Name;
+        var isAsync = IsAsyncMethod(method.MethodSymbol);
+        var isStatic = method.MethodSymbol.IsStatic;
+        var parameters = method.MethodSymbol.Parameters;
+
+        var target = isStatic ? fqName : $"(({fqName})receiver!)";
+
+        var argList = "";
+        if (parameters.Length == 1)
+        {
+            // Single argument is boxed directly (no ValueTuple wrapper).
+            argList = $"({parameters[0].Type.ToDisplayString()})theoryArgs!";
+        }
+        else if (parameters.Length > 1)
+        {
+            // Cast straight to the concrete tuple type so arguments are strongly
+            // typed (no per-element unboxing cast via ITuple's object indexer).
+            builder.AppendLine($"var args = ({BuildValueTupleType(parameters)})theoryArgs!;");
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (i > 0)
+                    sb.Append(", ");
+
+                sb.Append($"args.Item{i + 1}");
+            }
+            argList = sb.ToString();
+        }
+
+        var awaitKeyword = isAsync ? "await " : "";
+        builder.AppendLine($"{awaitKeyword}{target}.{methodName}({argList});");
+    }
+
+    private static string BuildValueTupleType(ImmutableArray<IParameterSymbol> parameters)
+    {
+        var types = parameters.Select(p => p.Type.ToDisplayString());
+        return $"global::System.ValueTuple<{string.Join(", ", types)}>";
+    }
+
     private static void GenerateFactMetadata(
         IndentingBuilder builder,
         TestMethodInfo method)
@@ -203,8 +298,6 @@ public sealed class TestGenerator : IIncrementalGenerator
         var methodName = method.MethodSymbol.Name;
         var isAsync = IsAsyncMethod(method.MethodSymbol);
         var isStatic = method.MethodSymbol.IsStatic;
-        var containingTypeName = method.ContainingClass.ToDisplayString();
-        var implementsIDisposable = ImplementsIDisposable(method.ContainingClass);
 
         builder.AppendLine("new TestMethodMetadata.Fact");
         builder.AppendLine("{");
@@ -212,40 +305,6 @@ public sealed class TestGenerator : IIncrementalGenerator
         builder.AppendLine($"MethodName = \"{methodName}\",");
         builder.AppendLine($"IsAsync = {(isAsync ? "true" : "false")},");
         builder.AppendLine($"IsStatic = {(isStatic ? "true" : "false")},");
-        builder.AppendLine("Body = async (ct) =>");
-        builder.AppendLine("{");
-        builder.Indent();
-
-        if (isStatic)
-        {
-            if (isAsync)
-            {
-                builder.AppendLine($"await {containingTypeName}.{methodName}();");
-            }
-            else
-            {
-                builder.AppendLine($"{containingTypeName}.{methodName}();");
-            }
-        }
-        else
-        {
-            builder.AppendLine($"var instance = new {containingTypeName}();");
-            if (isAsync)
-            {
-                builder.AppendLine($"await instance.{methodName}();");
-            }
-            else
-            {
-                builder.AppendLine($"instance.{methodName}();");
-            }
-            if (implementsIDisposable)
-            {
-                builder.AppendLine("((IDisposable)instance).Dispose();");
-            }
-        }
-
-        builder.Dedent();
-        builder.AppendLine("}");
         builder.Dedent();
         builder.AppendLine("},");
     }
@@ -257,8 +316,6 @@ public sealed class TestGenerator : IIncrementalGenerator
         var methodName = method.MethodSymbol.Name;
         var isAsync = IsAsyncMethod(method.MethodSymbol);
         var isStatic = method.MethodSymbol.IsStatic;
-        var containingTypeName = method.ContainingClass.ToDisplayString();
-        var implementsIDisposable = ImplementsIDisposable(method.ContainingClass);
         var parameters = method.MethodSymbol.Parameters;
 
         builder.AppendLine("new TestMethodMetadata.Theory");
@@ -267,18 +324,25 @@ public sealed class TestGenerator : IIncrementalGenerator
         builder.AppendLine($"MethodName = \"{methodName}\",");
         builder.AppendLine($"IsAsync = {(isAsync ? "true" : "false")},");
         builder.AppendLine($"IsStatic = {(isStatic ? "true" : "false")},");
-        builder.AppendLine("TestCases = new TestCaseMetadata[]");
+        builder.AppendLine("TestCases = new TestCaseInfo[]");
         builder.AppendLine("{");
         builder.Indent();
 
         foreach (var testCase in method.InlineDataCases)
         {
-            builder.AppendLine("new TestCaseMetadata");
+            builder.AppendLine("new TestCaseInfo");
             builder.AppendLine("{");
             builder.Indent();
 
-            var args = testCase.Arguments.Select(FormatConstantValue);
-            builder.AppendLine($"Arguments = new object?[] {{ {string.Join(", ", args)} }},");
+            var args = testCase.Arguments.Select(FormatConstantValue).ToList();
+            // 1 arg: box the value directly. 2+ args: tuple literal. 0 args: null.
+            var arguments = args.Count switch
+            {
+                0 => "null",
+                1 => args[0],
+                _ => $"({string.Join(", ", args)})",
+            };
+            builder.AppendLine($"Arguments = {arguments},");
 
             // Generate DisplayName with parameter names and values (e.g., "a: 1, b: 2, expected: 3")
             var displayNameParts = new List<string>();
@@ -289,7 +353,7 @@ public sealed class TestGenerator : IIncrementalGenerator
                 displayNameParts.Add($"{paramName}: {paramValue}");
             }
             var displayName = EscapeString(string.Join(", ", displayNameParts));
-            builder.AppendLine($"DisplayName = \"{displayName}\"");
+            builder.AppendLine($"DisplayName = \"{displayName}\",");
 
             builder.Dedent();
             builder.AppendLine("},");
@@ -297,63 +361,8 @@ public sealed class TestGenerator : IIncrementalGenerator
 
         builder.Dedent();
         builder.AppendLine("},");
-        builder.AppendLine("ParameterizedBody = async (args, ct) =>");
-        builder.AppendLine("{");
-        builder.Indent();
-
-        if (isStatic)
-        {
-            var methodCall = GenerateMethodCall(containingTypeName, methodName, parameters, isAsync);
-            builder.AppendLine(methodCall);
-        }
-        else
-        {
-            builder.AppendLine($"var instance = new {containingTypeName}();");
-            var methodCall = GenerateMethodCall("instance", methodName, parameters, isAsync);
-            builder.AppendLine(methodCall);
-            if (implementsIDisposable)
-            {
-                builder.AppendLine("((IDisposable)instance).Dispose();");
-            }
-        }
-
-        builder.Dedent();
-        builder.AppendLine("}");
         builder.Dedent();
         builder.AppendLine("},");
-    }
-
-    private static string GenerateMethodCall(
-        string target,
-        string methodName,
-        ImmutableArray<IParameterSymbol> parameters,
-        bool isAsync)
-    {
-        var sb = new StringBuilder();
-
-        if (isAsync)
-        {
-            sb.Append("await ");
-        }
-
-        sb.Append(target);
-        sb.Append('.');
-        sb.Append(methodName);
-        sb.Append('(');
-
-        for (int i = 0; i < parameters.Length; i++)
-        {
-            if (i > 0)
-                sb.Append(", ");
-
-            var param = parameters[i];
-            var typeName = param.Type.ToDisplayString();
-
-            sb.Append($"({typeName})args[{i}]!");
-        }
-
-        sb.Append(");");
-        return sb.ToString();
     }
 
     private static void GenerateTestRegistry(
@@ -401,12 +410,6 @@ public sealed class TestGenerator : IIncrementalGenerator
     private static bool IsAsyncMethod(IMethodSymbol method)
     {
         return method.ReturnType.Name == "Task" || method.ReturnType.Name == "ValueTask";
-    }
-
-    private static bool ImplementsIDisposable(INamedTypeSymbol type)
-    {
-        return type.AllInterfaces.Any(i =>
-            i.ToDisplayString() == "System.IDisposable");
     }
 
     private static string GetSafeClassName(INamedTypeSymbol type)

--- a/src/UXUnit.Runtime/TestExecutionEngine.cs
+++ b/src/UXUnit.Runtime/TestExecutionEngine.cs
@@ -211,8 +211,7 @@ public static class TestExecutionEngine
                     testId,
                     methodName,
                     test.Method.SkipReason ?? "Test marked as skipped",
-                    test.ClassName,
-                    test.Class.AssemblyName
+                    test.ClassName
                 )
             ];
         }
@@ -232,8 +231,7 @@ public static class TestExecutionEngine
                     methodName,
                     ex.Message,
                     ex.StackTrace,
-                    test.ClassName,
-                    test.Class.AssemblyName
+                    test.ClassName
                 )
             ];
         }
@@ -254,8 +252,7 @@ public static class TestExecutionEngine
                                 testClassInstance,
                                 methodName,
                                 null,
-                                test.ClassName,
-                                test.Class.AssemblyName
+                                test.ClassName
                             )
                         ];
                     }
@@ -275,8 +272,7 @@ public static class TestExecutionEngine
                             testClassInstance,
                             methodName,
                             cases[i].Arguments,
-                            test.ClassName,
-                            test.Class.AssemblyName
+                            test.ClassName
                         );
                     }
                     return results;
@@ -302,8 +298,7 @@ public static class TestExecutionEngine
             object? testClassInstance,
             string methodName,
             object? theoryArgs,
-            string className,
-            string assemblyName
+            string className
         )
         {
             var sw = new Stopwatch();
@@ -321,8 +316,7 @@ public static class TestExecutionEngine
                         testName,
                         ex,
                         sw.Elapsed,
-                        className,
-                        assemblyName
+                        className
                     );
             }
             sw.Stop();
@@ -330,8 +324,7 @@ public static class TestExecutionEngine
                 testId,
                 testName,
                 sw.Elapsed,
-                className,
-                assemblyName
+                className
             );
         }
     }

--- a/src/UXUnit.Runtime/TestExecutionEngine.cs
+++ b/src/UXUnit.Runtime/TestExecutionEngine.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,14 +28,12 @@ public static class TestExecutionEngine
     {
         var allTests = CollectAllTests(testClasses);
 
-        if (options.ParallelExecution && allTests.Count > 1)
+        return options.Mode switch
         {
-            return await ExecuteInParallelAsync(allTests, options, cancellationToken);
-        }
-        else
-        {
-            return await ExecuteSequentiallyAsync(allTests, options, cancellationToken);
-        }
+            ParallelMode.None => await ExecuteSequentiallyAsync(allTests, options, cancellationToken),
+            ParallelMode.Classes => await ExecuteClassesInParallelAsync(allTests, options, cancellationToken),
+            _ => await ExecuteTestsInParallelAsync(allTests, options, cancellationToken),
+        };
     }
 
     internal static List<TestDescriptor> CollectAllTests(
@@ -55,37 +54,40 @@ public static class TestExecutionEngine
                         tests.Add(
                             new TestDescriptor
                             {
-                                Metadata = fact,
-                                TestCase = null,
-                                TestCaseIndex = -1,
-                                ClassName = testClass.ClassName,
-                                AssemblyName = testClass.AssemblyName,
+                                Method = fact,
+                                Class = testClass,
                             }
                         );
                         break;
 
                     case TestMethodMetadata.Theory theory:
-                        // Theory: Execute once per test case
-                        for (int i = 0; i < theory.TestCases.Count; i++)
-                        {
-                            var testCase = theory.TestCases[i];
-                            tests.Add(
-                                new TestDescriptor
-                                {
-                                    Metadata = theory,
-                                    TestCase = testCase,
-                                    TestCaseIndex = i,
-                                    ClassName = testClass.ClassName,
-                                    AssemblyName = testClass.AssemblyName,
-                                }
-                            );
-                        }
+                        // Theory: a single descriptor; ExecuteTestAsync expands the cases.
+                        tests.Add(
+                            new TestDescriptor
+                            {
+                                Method = theory,
+                                Class = testClass,
+                            }
+                        );
                         break;
                 }
             }
         }
 
+        // Randomly permute tests on each run to surface accidental ordering dependencies.
+        Shuffle(tests);
+
         return tests;
+    }
+
+    private static void Shuffle(List<TestDescriptor> tests)
+    {
+        // Fisher-Yates shuffle using a thread-safe shared RNG.
+        for (int i = tests.Count - 1; i > 0; i--)
+        {
+            int j = Random.Shared.Next(i + 1);
+            (tests[i], tests[j]) = (tests[j], tests[i]);
+        }
     }
 
     private static async Task<TestResult[]> ExecuteSequentiallyAsync(
@@ -94,30 +96,30 @@ public static class TestExecutionEngine
         CancellationToken cancellationToken
     )
     {
-        var results = new List<TestResult>(tests.Count);
+        var allResults = new List<TestResult>(tests.Count);
 
         foreach (var test in tests)
         {
             if (cancellationToken.IsCancellationRequested)
                 break;
 
-            var result = await ExecuteTestAsync(test, options, cancellationToken);
-            results.Add(result);
+            var results = await ExecuteTestAsync(test, options, cancellationToken);
+            allResults.AddRange(results);
 
-            if (options.StopOnFirstFailure && result.Status == TestStatus.Failed)
+            if (options.StopOnFirstFailure && results.Any(r => r.Status == TestStatus.Failed))
                 break;
         }
 
-        return results.ToArray();
+        return allResults.ToArray();
     }
 
-    private static async Task<TestResult[]> ExecuteInParallelAsync(
+    private static async Task<TestResult[]> ExecuteTestsInParallelAsync(
         List<TestDescriptor> tests,
         TestExecutionOptions options,
         CancellationToken cancellationToken
     )
     {
-        var results = new System.Collections.Concurrent.ConcurrentBag<TestResult>();
+        var allResults = new System.Collections.Concurrent.ConcurrentBag<TestResult>();
         var shouldStop = false;
 
         await Parallel.ForEachAsync(
@@ -132,119 +134,211 @@ public static class TestExecutionEngine
                 if (options.StopOnFirstFailure && shouldStop)
                     return;
 
-                var result = await ExecuteTestAsync(test, options, ct);
-                results.Add(result);
+                var results = await ExecuteTestAsync(test, options, ct);
+                foreach (var result in results)
+                {
+                    allResults.Add(result);
+                }
 
-                if (options.StopOnFirstFailure && result.Status == TestStatus.Failed)
+                if (options.StopOnFirstFailure && results.Any(r => r.Status == TestStatus.Failed))
                     shouldStop = true;
             }
         );
 
-        return results.OrderBy(r => r.TestId).ToArray();
+        return allResults.OrderBy(r => r.TestId).ToArray();
     }
 
-    internal static async Task<TestResult> ExecuteTestAsync(
+    private static async Task<TestResult[]> ExecuteClassesInParallelAsync(
+        List<TestDescriptor> tests,
+        TestExecutionOptions options,
+        CancellationToken cancellationToken
+    )
+    {
+        // Classes run in parallel; tests within a class run sequentially.
+        var classGroups = tests.GroupBy(t => t.ClassName, StringComparer.Ordinal);
+
+        var allResults = new System.Collections.Concurrent.ConcurrentBag<TestResult>();
+        var shouldStop = false;
+
+        await Parallel.ForEachAsync(
+            classGroups,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = options.MaxDegreeOfParallelism,
+                CancellationToken = cancellationToken,
+            },
+            async (group, ct) =>
+            {
+                foreach (var test in group)
+                {
+                    if (ct.IsCancellationRequested)
+                        break;
+
+                    if (options.StopOnFirstFailure && shouldStop)
+                        break;
+
+                    var results = await ExecuteTestAsync(test, options, ct);
+                    foreach (var result in results)
+                    {
+                        allResults.Add(result);
+
+                        if (options.StopOnFirstFailure && result.Status == TestStatus.Failed)
+                            shouldStop = true;
+                    }
+                }
+            }
+        );
+
+        return allResults.OrderBy(r => r.TestId).ToArray();
+    }
+
+    internal static async Task<TestResult[]> ExecuteTestAsync(
         TestDescriptor test,
         TestExecutionOptions options,
         CancellationToken cancellationToken
     )
     {
         var testId = GenerateTestId(test);
-        var testName = GenerateTestName(test);
+        var methodName = test.Method.MethodName;
 
-        // Check if test case should be skipped
-        if (test.TestCase?.Skip == true)
-        {
-            return TestResult.Skipped(
-                testId,
-                testName,
-                test.TestCase.SkipReason ?? "Test case marked as skipped",
-                test.ClassName,
-                test.AssemblyName
-            );
-        }
 
         // Check if test method should be skipped
-        if (test.Metadata.Skip)
+        if (test.Method.Skip)
         {
-            return TestResult.Skipped(
-                testId,
-                testName,
-                test.Metadata.SkipReason ?? "Test marked as skipped",
-                test.ClassName,
-                test.AssemblyName
-            );
+            return
+            [
+                TestResult.Skipped(
+                    testId,
+                    methodName,
+                    test.Method.SkipReason ?? "Test marked as skipped",
+                    test.ClassName,
+                    test.Class.AssemblyName
+                )
+            ];
         }
 
-        var startTime = DateTime.UtcNow;
-
+        object? testClassInstance = null;
         try
         {
-            // Pattern match on Fact vs Theory
-            switch (test.Metadata)
-            {
-                case TestMethodMetadata.Fact fact:
-                    if (fact.Body != null)
-                    {
-                        await fact.Body(cancellationToken);
-                    }
-                    // else: No body - test passes (placeholder for generator)
-                    break;
-
-                case TestMethodMetadata.Theory theory:
-                    if (test.TestCase == null)
-                    {
-                        throw new InvalidOperationException(
-                            "Theory test descriptor must have a TestCase"
-                        );
-                    }
-                    if (theory.ParameterizedBody != null)
-                    {
-                        await theory.ParameterizedBody(test.TestCase.Arguments, cancellationToken);
-                    }
-                    // else: No body - test passes (placeholder for generator)
-                    break;
-
-                default:
-                    throw new InvalidOperationException(
-                        $"Unknown test method type: {test.Metadata.GetType()}"
-                    );
-            }
-
-            // If we get here, test passed
-            var endTime = DateTime.UtcNow;
-            return TestResult.Success(
-                testId,
-                testName,
-                endTime - startTime,
-                test.ClassName,
-                test.AssemblyName
-            );
+            testClassInstance = test.Class.CreateInstance();
         }
         catch (Exception ex)
         {
-            // If the delegate throws, create a failure result
-            var endTime = DateTime.UtcNow;
-            return TestResult.Failure(
+            // If the delegate throws, create a fault result
+            return
+            [
+                TestResult.Fault(
+                    testId,
+                    methodName,
+                    ex.Message,
+                    ex.StackTrace,
+                    test.ClassName,
+                    test.Class.AssemblyName
+                )
+            ];
+        }
+
+        // Pattern match on Fact vs Theory
+        try
+        {
+            switch (test.Method)
+            {
+                case TestMethodMetadata.Fact fact:
+                    {
+                        return
+                        [
+                            await RunTest(
+                                testId,
+                                methodName,
+                                test.Class.TestDispatch,
+                                testClassInstance,
+                                methodName,
+                                null,
+                                test.ClassName,
+                                test.Class.AssemblyName
+                            )
+                        ];
+                    }
+
+                case TestMethodMetadata.Theory theory:
+                    var cases = theory.TestCases;
+                    var results = new TestResult[cases.Count];
+                    for (int i = 0; i < cases.Count; i++)
+                    {
+                        // Match xUnit's per-case naming: MethodName(displayName)
+                        var caseName = $"{methodName}({cases[i].DisplayName})";
+                        var caseId = $"{testId}({cases[i].DisplayName})";
+                        results[i] = await RunTest(
+                            caseId,
+                            caseName,
+                            test.Class.TestDispatch,
+                            testClassInstance,
+                            methodName,
+                            cases[i].Arguments,
+                            test.ClassName,
+                            test.Class.AssemblyName
+                        );
+                    }
+                    return results;
+
+                default:
+                    throw new InvalidOperationException(
+                        $"Unknown test method type: {test.Method.GetType()}"
+                    );
+            }
+        }
+        finally
+        {
+            if (testClassInstance is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        static async Task<TestResult> RunTest(
+            string testId,
+            string testName,
+            TestClassMetadata.DispatchFunc dispatch,
+            object? testClassInstance,
+            string methodName,
+            object? theoryArgs,
+            string className,
+            string assemblyName
+        )
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+            try
+            {
+                await dispatch(testClassInstance, methodName, theoryArgs);
+            }
+            catch (Exception ex)
+            {
+                // If the delegate throws, create a failure result
+                sw.Stop();
+                return TestResult.Failure(
+                        testId,
+                        testName,
+                        ex,
+                        sw.Elapsed,
+                        className,
+                        assemblyName
+                    );
+            }
+            sw.Stop();
+            return TestResult.Success(
                 testId,
                 testName,
-                ex,
-                endTime - startTime,
-                test.ClassName,
-                test.AssemblyName
+                sw.Elapsed,
+                className,
+                assemblyName
             );
         }
     }
 
     private static string GenerateTestName(TestDescriptor test)
     {
-        var baseName = test.Metadata.MethodName;
-
-        // If this is a test case with a display name, append it
-        if (test.TestCase?.DisplayName != null)
-        {
-            return $"{baseName}({test.TestCase.DisplayName})";
-        }
+        var baseName = test.Method.MethodName;
 
         // Regular test without cases
         return baseName;
@@ -252,19 +346,7 @@ public static class TestExecutionEngine
 
     private static string GenerateTestId(TestDescriptor test)
     {
-        var baseId = $"{test.ClassName}.{test.Metadata.MethodName}";
-
-        // If this is a test case with a display name, use it
-        if (test.TestCase?.DisplayName != null)
-        {
-            return $"{baseId}({test.TestCase.DisplayName})";
-        }
-
-        // If this is a test case with an index, include it
-        if (test.TestCaseIndex >= 0)
-        {
-            return $"{baseId}[{test.TestCaseIndex}]";
-        }
+        var baseId = test.DisplayName;
 
         // Regular test without cases
         return baseId;
@@ -272,10 +354,10 @@ public static class TestExecutionEngine
 
     internal class TestDescriptor
     {
-        public required TestMethodMetadata Metadata { get; init; }
-        public required string ClassName { get; init; }
-        public required string AssemblyName { get; init; }
-        public TestCaseMetadata? TestCase { get; init; }
-        public int TestCaseIndex { get; init; } = -1;
+        public required TestClassMetadata Class { get; init; }
+        public required TestMethodMetadata Method { get; init; }
+
+        public string ClassName => Class.ClassName;
+        public string DisplayName => Class.DisplayName ?? Class.ClassName + "." + Method.MethodName;
     }
 }

--- a/src/UXUnit.Runtime/TestExecutionOptions.cs
+++ b/src/UXUnit.Runtime/TestExecutionOptions.cs
@@ -3,11 +3,39 @@ using System;
 namespace UXUnit.Runtime;
 
 /// <summary>
+/// Controls how tests are parallelized during execution.
+/// </summary>
+public enum ParallelMode
+{
+    /// <summary>
+    /// Everything runs sequentially.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Test classes run in parallel with one another, but the tests within a
+    /// single class run sequentially.
+    /// </summary>
+    Classes,
+
+    /// <summary>
+    /// Individual tests run in parallel, regardless of which class they belong
+    /// to. This is the default.
+    /// </summary>
+    Tests,
+}
+
+/// <summary>
 /// Configuration options for test execution.
 /// </summary>
 public sealed class TestExecutionOptions
 {
-    public bool ParallelExecution { get; init; } = true;
+    /// <summary>
+    /// Controls parallelization. Defaults to running every test in parallel.
+    /// Regardless of mode, tests are randomly permuted on each run to surface
+    /// accidental ordering dependencies.
+    /// </summary>
+    public ParallelMode Mode { get; init; } = ParallelMode.Tests;
 
     public int MaxDegreeOfParallelism { get; init; } = Environment.ProcessorCount;
 

--- a/src/UXUnit.Runtime/TestFramework.cs
+++ b/src/UXUnit.Runtime/TestFramework.cs
@@ -1,5 +1,6 @@
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Testing.Extensions;
@@ -115,56 +116,112 @@ public sealed class TestFramework : ITestFramework, IDataProducer
             context.CancellationToken
         ).Token;
 
-        var testMethods = TestExecutionEngine.CollectAllTests(_testClasses);
+        var tests = TestExecutionEngine.CollectAllTests(_testClasses);
 
-        await Parallel.ForEachAsync(
-            testMethods,
-            new ParallelOptions
-            {
-                MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
-                CancellationToken = linkedCt,
-            },
-            async (test, ct) =>
-            {
-                var result = await TestExecutionEngine.ExecuteTestAsync(test, _options, ct);
+        switch (_options.Mode)
+        {
+            case ParallelMode.None:
+                foreach (var test in tests)
+                {
+                    if (linkedCt.IsCancellationRequested)
+                        break;
 
-                if (_options.StopOnFirstFailure && result.Status == TestStatus.Failed)
-                    stopCts.Cancel();
+                    await RunAndPublishAsync(context, test, stopCts, linkedCt);
+                }
+                break;
 
-                await PublishTestResultAsync(context, result);
-            }
-        );
+            case ParallelMode.Classes:
+                var classGroups = tests.GroupBy(t => t.ClassName, StringComparer.Ordinal);
+
+                await Parallel.ForEachAsync(
+                    classGroups,
+                    new ParallelOptions
+                    {
+                        MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
+                        CancellationToken = linkedCt,
+                    },
+                    async (group, ct) =>
+                    {
+                        foreach (var test in group)
+                        {
+                            if (ct.IsCancellationRequested)
+                                break;
+
+                            await RunAndPublishAsync(context, test, stopCts, ct);
+                        }
+                    }
+                );
+                break;
+
+            default: // ParallelMode.Tests
+                await Parallel.ForEachAsync(
+                    tests,
+                    new ParallelOptions
+                    {
+                        MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
+                        CancellationToken = linkedCt,
+                    },
+                    async (test, ct) => await RunAndPublishAsync(context, test, stopCts, ct)
+                );
+                break;
+        }
     }
 
-    private async Task PublishTestResultAsync(ExecuteRequestContext context, TestResult result)
+    private async Task RunAndPublishAsync(
+        ExecuteRequestContext context,
+        TestExecutionEngine.TestDescriptor test,
+        CancellationTokenSource stopCts,
+        CancellationToken ct
+    )
     {
-        var testfqn = $"{result.ClassDisplayName ?? result.ClassName}.{result.TestName}";
-        TestNode testNode = result.Status switch
+        var results = await TestExecutionEngine.ExecuteTestAsync(test, _options, ct);
+
+        if (_options.StopOnFirstFailure && results.Any(r => r.Status == TestStatus.Failed))
+            stopCts.Cancel();
+
+        await PublishTestResultsAsync(context, results);
+    }
+
+    private async Task PublishTestResultsAsync(ExecuteRequestContext context, TestResult[] results)
+    {
+        foreach (var result in results)
         {
-            TestStatus.Skipped => new TestNode()
+            var testfqn = $"{result.ClassDisplayName ?? result.ClassName}.{result.TestName}";
+            TestNode testNode = result.Status switch
             {
-                Uid = testfqn,
-                DisplayName = testfqn,
-                Properties = new PropertyBag(new SkippedTestNodeStateProperty(result.SkipReason ?? ""))
-            },
-            TestStatus.Passed => new TestNode()
-            {
-                Uid = testfqn,
-                DisplayName = testfqn,
-                Properties = new PropertyBag(new PassedTestNodeStateProperty())
-            },
-            TestStatus.Failed => new TestNode()
-            {
-                Uid = testfqn,
-                DisplayName = testfqn,
-                Properties = new PropertyBag(
-                    new FailedTestNodeStateProperty(result.ErrorMessage!),
-                    new TrxExceptionProperty(result.ErrorMessage, result.StackTrace)
-                )
-            },
-            _ => throw new InvalidOperationException($"Unknown test status {result.Status}")
-        };
-        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, testNode));
+                TestStatus.Skipped => new TestNode()
+                {
+                    Uid = testfqn,
+                    DisplayName = testfqn,
+                    Properties = new PropertyBag(new SkippedTestNodeStateProperty(result.SkipReason ?? ""))
+                },
+                TestStatus.Passed => new TestNode()
+                {
+                    Uid = testfqn,
+                    DisplayName = testfqn,
+                    Properties = new PropertyBag(new PassedTestNodeStateProperty())
+                },
+                TestStatus.Failed => new TestNode()
+                {
+                    Uid = testfqn,
+                    DisplayName = testfqn,
+                    Properties = new PropertyBag(
+                        new FailedTestNodeStateProperty(result.ErrorMessage!),
+                        new TrxExceptionProperty(result.ErrorMessage, result.StackTrace)
+                    )
+                },
+                TestStatus.Faulted => new TestNode()
+                {
+                    Uid = testfqn,
+                    DisplayName = testfqn,
+                    Properties = new PropertyBag(
+                        new ErrorTestNodeStateProperty(result.ErrorMessage ?? "Test infrastructure fault"),
+                        new TrxExceptionProperty(result.ErrorMessage, result.StackTrace)
+                    )
+                }
+            };
+            await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(context.Request.Session.SessionUid, testNode));
+        }
     }
 
     public async Task<bool> IsEnabledAsync() => true;

--- a/src/UXUnit.Runtime/UXUnit.Runtime.csproj
+++ b/src/UXUnit.Runtime/UXUnit.Runtime.csproj
@@ -23,5 +23,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="Microsoft.Testing.Platform" />
+    <PackageReference Include="StaticCS">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/test/Assets/UXUnitCompat/Program.cs
+++ b/test/Assets/UXUnitCompat/Program.cs
@@ -14,8 +14,7 @@ class Program
 
         var options = new TestExecutionOptions
         {
-            MaxDegreeOfParallelism = 1, // Run sequentially for easier comparison with XUnit
-            ParallelExecution = false
+            Mode = ParallelMode.None, // Run sequentially for easier comparison with XUnit
         };
 
         return await TestFramework.RunAsync(args, allTests, options);

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForAsyncTest#AsyncTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForAsyncTest#AsyncTests_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "AsyncTests",
-                AssemblyName = "GeneratesMetadataForAsyncTest",
                 CreateInstance = () => new global::AsyncTests(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForAsyncTest#AsyncTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForAsyncTest#AsyncTests_Metadata.g.verified.cs
@@ -18,6 +18,21 @@ namespace UXUnit.Generated
             {
                 ClassName = "AsyncTests",
                 AssemblyName = "GeneratesMetadataForAsyncTest",
+                CreateInstance = () => new global::AsyncTests(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "AsyncPassingTest":
+                        {
+                            await ((global::AsyncTests)receiver!).AsyncPassingTest();
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Fact
@@ -25,11 +40,6 @@ namespace UXUnit.Generated
                         MethodName = "AsyncPassingTest",
                         IsAsync = true,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new AsyncTests();
-                            await instance.AsyncPassingTest();
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForMultipleTestMethods#MixedTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForMultipleTestMethods#MixedTests_Metadata.g.verified.cs
@@ -18,6 +18,31 @@ namespace UXUnit.Generated
             {
                 ClassName = "MixedTests",
                 AssemblyName = "GeneratesMetadataForMultipleTestMethods",
+                CreateInstance = () => new global::MixedTests(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "Test1":
+                        {
+                            ((global::MixedTests)receiver!).Test1();
+                            break;
+                        }
+                        case "Test2":
+                        {
+                            ((global::MixedTests)receiver!).Test2();
+                            break;
+                        }
+                        case "StringTest":
+                        {
+                            ((global::MixedTests)receiver!).StringTest((string)theoryArgs!);
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Fact
@@ -25,46 +50,31 @@ namespace UXUnit.Generated
                         MethodName = "Test1",
                         IsAsync = false,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new MixedTests();
-                            instance.Test1();
-                        }
                     },
                     new TestMethodMetadata.Fact
                     {
                         MethodName = "Test2",
                         IsAsync = false,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new MixedTests();
-                            instance.Test2();
-                        }
                     },
                     new TestMethodMetadata.Theory
                     {
                         MethodName = "StringTest",
                         IsAsync = false,
                         IsStatic = false,
-                        TestCases = new TestCaseMetadata[]
+                        TestCases = new TestCaseInfo[]
                         {
-                            new TestCaseMetadata
+                            new TestCaseInfo
                             {
-                                Arguments = new object?[] { "hello" },
-                                DisplayName = "input: \\\"hello\\\""
+                                Arguments = "hello",
+                                DisplayName = "input: \\\"hello\\\"",
                             },
-                            new TestCaseMetadata
+                            new TestCaseInfo
                             {
-                                Arguments = new object?[] { "world" },
-                                DisplayName = "input: \\\"world\\\""
+                                Arguments = "world",
+                                DisplayName = "input: \\\"world\\\"",
                             },
                         },
-                        ParameterizedBody = async (args, ct) =>
-                        {
-                            var instance = new MixedTests();
-                            instance.StringTest((string)args[0]!);
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForMultipleTestMethods#MixedTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForMultipleTestMethods#MixedTests_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "MixedTests",
-                AssemblyName = "GeneratesMetadataForMultipleTestMethods",
                 CreateInstance = () => new global::MixedTests(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForSimpleFact#SimpleTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForSimpleFact#SimpleTests_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "SimpleTests",
-                AssemblyName = "GeneratesMetadataForSimpleFact",
                 CreateInstance = () => new global::SimpleTests(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForSimpleFact#SimpleTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForSimpleFact#SimpleTests_Metadata.g.verified.cs
@@ -18,6 +18,21 @@ namespace UXUnit.Generated
             {
                 ClassName = "SimpleTests",
                 AssemblyName = "GeneratesMetadataForSimpleFact",
+                CreateInstance = () => new global::SimpleTests(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "PassingTest":
+                        {
+                            ((global::SimpleTests)receiver!).PassingTest();
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Fact
@@ -25,11 +40,6 @@ namespace UXUnit.Generated
                         MethodName = "PassingTest",
                         IsAsync = false,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new SimpleTests();
-                            instance.PassingTest();
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
@@ -18,6 +18,22 @@ namespace UXUnit.Generated
             {
                 ClassName = "MathTests",
                 AssemblyName = "GeneratesMetadataForTheoryWithInlineData",
+                CreateInstance = () => new global::MathTests(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "AddTest":
+                        {
+                            var args = (global::System.ValueTuple<int, int, int>)theoryArgs!;
+                            ((global::MathTests)receiver!).AddTest(args.Item1, args.Item2, args.Item3);
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Theory
@@ -25,24 +41,19 @@ namespace UXUnit.Generated
                         MethodName = "AddTest",
                         IsAsync = false,
                         IsStatic = false,
-                        TestCases = new TestCaseMetadata[]
+                        TestCases = new TestCaseInfo[]
                         {
-                            new TestCaseMetadata
+                            new TestCaseInfo
                             {
-                                Arguments = new object?[] { 1, 2, 3 },
-                                DisplayName = "a: 1, b: 2, sum: 3"
+                                Arguments = (1, 2, 3),
+                                DisplayName = "a: 1, b: 2, sum: 3",
                             },
-                            new TestCaseMetadata
+                            new TestCaseInfo
                             {
-                                Arguments = new object?[] { 5, 7, 12 },
-                                DisplayName = "a: 5, b: 7, sum: 12"
+                                Arguments = (5, 7, 12),
+                                DisplayName = "a: 5, b: 7, sum: 12",
                             },
                         },
-                        ParameterizedBody = async (args, ct) =>
-                        {
-                            var instance = new MathTests();
-                            instance.AddTest((int)args[0]!, (int)args[1]!, (int)args[2]!);
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "MathTests",
-                AssemblyName = "GeneratesMetadataForTheoryWithInlineData",
                 CreateInstance = () => new global::MathTests(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass1_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass1_Metadata.g.verified.cs
@@ -18,6 +18,21 @@ namespace UXUnit.Generated
             {
                 ClassName = "TestClass1",
                 AssemblyName = "GeneratesSeparateFilesForDifferentClasses",
+                CreateInstance = () => new global::TestClass1(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "Test1":
+                        {
+                            ((global::TestClass1)receiver!).Test1();
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Fact
@@ -25,11 +40,6 @@ namespace UXUnit.Generated
                         MethodName = "Test1",
                         IsAsync = false,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new TestClass1();
-                            instance.Test1();
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass1_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass1_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "TestClass1",
-                AssemblyName = "GeneratesSeparateFilesForDifferentClasses",
                 CreateInstance = () => new global::TestClass1(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass2_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass2_Metadata.g.verified.cs
@@ -17,7 +17,6 @@ namespace UXUnit.Generated
             new TestClassMetadata
             {
                 ClassName = "TestClass2",
-                AssemblyName = "GeneratesSeparateFilesForDifferentClasses",
                 CreateInstance = () => new global::TestClass2(),
                 TestDispatch = async (receiver, methodName, theoryArgs) =>
                 {

--- a/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass2_Metadata.g.verified.cs
+++ b/test/UXUnit.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesSeparateFilesForDifferentClasses#TestClass2_Metadata.g.verified.cs
@@ -18,6 +18,21 @@ namespace UXUnit.Generated
             {
                 ClassName = "TestClass2",
                 AssemblyName = "GeneratesSeparateFilesForDifferentClasses",
+                CreateInstance = () => new global::TestClass2(),
+                TestDispatch = async (receiver, methodName, theoryArgs) =>
+                {
+                    switch (methodName)
+                    {
+                        case "Test2":
+                        {
+                            ((global::TestClass2)receiver!).Test2();
+                            break;
+                        }
+                        default:
+                            throw new global::System.InvalidOperationException("Unknown test method: " + methodName);
+                    }
+                    await global::System.Threading.Tasks.Task.CompletedTask;
+                },
                 TestMethods = new TestMethodMetadata[]
                 {
                     new TestMethodMetadata.Fact
@@ -25,11 +40,6 @@ namespace UXUnit.Generated
                         MethodName = "Test2",
                         IsAsync = false,
                         IsStatic = false,
-                        Body = async (ct) =>
-                        {
-                            var instance = new TestClass2();
-                            instance.Test2();
-                        }
                     },
                 },
             };

--- a/test/UXUnit.Runtime.Tests/ExecutionEngineTests.cs
+++ b/test/UXUnit.Runtime.Tests/ExecutionEngineTests.cs
@@ -21,7 +21,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SimpleTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "SimplePassingTest", Skip = false },
@@ -62,7 +61,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SkippedTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact
@@ -95,7 +93,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "MultiTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "Test1", Skip = false },
@@ -129,7 +126,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SequentialTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "Test1" },
@@ -157,7 +153,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "ParallelTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "ParallelTest1" },
@@ -190,7 +185,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "StopOnFailureTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "Test1" },
@@ -222,7 +216,6 @@ public class ExecutionEngineTests
             new TestClassMetadata
             {
                 ClassName = "TestClass1",
-                AssemblyName = "TestAssembly",
                 TestMethods =
                 [
                     new TestMethodMetadata.Fact { MethodName = "Test1A" },
@@ -234,7 +227,6 @@ public class ExecutionEngineTests
             new TestClassMetadata
             {
                 ClassName = "TestClass2",
-                AssemblyName = "TestAssembly",
                 TestMethods =
                 [
                     new TestMethodMetadata.Fact { MethodName = "Test2A" },
@@ -263,7 +255,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TimingTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods = [new TestMethodMetadata.Fact { MethodName = "TimedTest" }],
             CreateInstance = () => null,
             TestDispatch = (_, _, _) => Task.CompletedTask,
@@ -286,7 +277,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "FailingTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "FailingTest", Skip = false },
@@ -320,7 +310,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "AsyncTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "AsyncTest", IsAsync = true },
@@ -358,7 +347,6 @@ public class ExecutionEngineTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SequentialWithinClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "T1" },
@@ -403,7 +391,6 @@ public class ExecutionEngineTests
         var classA = new TestClassMetadata
         {
             ClassName = "ClassA",
-            AssemblyName = "TestAssembly",
             TestMethods = [new TestMethodMetadata.Fact { MethodName = "A1" }],
             CreateInstance = () => null,
             TestDispatch = async (_, _, _) =>
@@ -416,7 +403,6 @@ public class ExecutionEngineTests
         var classB = new TestClassMetadata
         {
             ClassName = "ClassB",
-            AssemblyName = "TestAssembly",
             TestMethods = [new TestMethodMetadata.Fact { MethodName = "B1" }],
             CreateInstance = () => null,
             TestDispatch = async (_, _, _) =>
@@ -451,7 +437,6 @@ public class ExecutionEngineTests
             var metadata = new TestClassMetadata
             {
                 ClassName = "PermuteClass",
-                AssemblyName = "TestAssembly",
                 TestMethods = Enumerable
                     .Range(0, 25)
                     .Select(i => (TestMethodMetadata)new TestMethodMetadata.Fact { MethodName = $"T{i:D2}" })

--- a/test/UXUnit.Runtime.Tests/ExecutionEngineTests.cs
+++ b/test/UXUnit.Runtime.Tests/ExecutionEngineTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using XunitAssert = Xunit.Assert;
 using XunitFactAttribute = Xunit.FactAttribute;
@@ -9,34 +10,35 @@ namespace UXUnit.Runtime.Tests;
 /// <summary>
 /// Tests that validate the TestExecutionEngine.
 /// These are XUnit tests that test our UXUnit runtime by manually synthesizing
-/// test metadata and delegates.
+/// test metadata and dispatch delegates.
 /// </summary>
 public class ExecutionEngineTests
 {
     [XunitFact]
     public async Task ExecuteTestsAsync_WithSimplePassingTest_ReturnsPassedResult()
     {
-        // Arrange: Create a simple test with a delegate that succeeds
-        var executed = false;
+        bool executed = false;
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SimpleTestClass",
             AssemblyName = "TestAssembly",
             TestMethods =
             [
-                new TestMethodMetadata.Fact
-                {
-                    MethodName = "SimplePassingTest",
-                    Skip = false,
-                    Body = async (ct) =>
-                    {
-                        // This is the actual test code - just set a flag and succeed
-                        executed = true;
-                        await Task.CompletedTask;
-                        // No exception = test passes
-                    },
-                },
+                new TestMethodMetadata.Fact { MethodName = "SimplePassingTest", Skip = false },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (testClass, methodName, _) =>
+            {
+                switch (methodName)
+                {
+                    case "SimplePassingTest":
+                        executed = true;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown method: {methodName}");
+                }
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -70,6 +72,8 @@ public class ExecutionEngineTests
                     SkipReason = "Test intentionally skipped for testing",
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = TestExecutionOptions.Default;
@@ -103,6 +107,8 @@ public class ExecutionEngineTests
                     SkipReason = "Skip this one",
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = TestExecutionOptions.Default;
@@ -130,9 +136,11 @@ public class ExecutionEngineTests
                 new TestMethodMetadata.Fact { MethodName = "Test2" },
                 new TestMethodMetadata.Fact { MethodName = "Test3" },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
-        var options = new TestExecutionOptions { ParallelExecution = false };
+        var options = new TestExecutionOptions { Mode = ParallelMode.None };
 
         // Act
         var results = await TestExecutionEngine.ExecuteTestsAsync([testMetadata], options);
@@ -157,11 +165,13 @@ public class ExecutionEngineTests
                 new TestMethodMetadata.Fact { MethodName = "ParallelTest3" },
                 new TestMethodMetadata.Fact { MethodName = "ParallelTest4" },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = new TestExecutionOptions
         {
-            ParallelExecution = true,
+            Mode = ParallelMode.Tests,
             MaxDegreeOfParallelism = 2,
         };
 
@@ -186,11 +196,13 @@ public class ExecutionEngineTests
                 new TestMethodMetadata.Fact { MethodName = "Test1" },
                 new TestMethodMetadata.Fact { MethodName = "Test2" },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = new TestExecutionOptions
         {
-            ParallelExecution = false,
+            Mode = ParallelMode.None,
             StopOnFirstFailure = true,
         };
 
@@ -210,22 +222,26 @@ public class ExecutionEngineTests
             new TestClassMetadata
             {
                 ClassName = "TestClass1",
-            AssemblyName = "TestAssembly",
+                AssemblyName = "TestAssembly",
                 TestMethods =
                 [
                     new TestMethodMetadata.Fact { MethodName = "Test1A" },
                     new TestMethodMetadata.Fact { MethodName = "Test1B" },
                 ],
+                CreateInstance = () => null,
+                TestDispatch = (_, _, _) => Task.CompletedTask,
             },
             new TestClassMetadata
             {
                 ClassName = "TestClass2",
-            AssemblyName = "TestAssembly",
+                AssemblyName = "TestAssembly",
                 TestMethods =
                 [
                     new TestMethodMetadata.Fact { MethodName = "Test2A" },
                     new TestMethodMetadata.Fact { MethodName = "Test2B" },
                 ],
+                CreateInstance = () => null,
+                TestDispatch = (_, _, _) => Task.CompletedTask,
             },
         };
 
@@ -249,6 +265,8 @@ public class ExecutionEngineTests
             ClassName = "TimingTestClass",
             AssemblyName = "TestAssembly",
             TestMethods = [new TestMethodMetadata.Fact { MethodName = "TimedTest" }],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = TestExecutionOptions.Default;
@@ -271,17 +289,15 @@ public class ExecutionEngineTests
             AssemblyName = "TestAssembly",
             TestMethods =
             [
-                new TestMethodMetadata.Fact
-                {
-                    MethodName = "FailingTest",
-                    Skip = false,
-                    Body = async (ct) =>
-                    {
-                        await Task.CompletedTask;
-                        throw new InvalidOperationException("Test intentionally failed");
-                    },
-                },
+                new TestMethodMetadata.Fact { MethodName = "FailingTest", Skip = false },
             ],
+            CreateInstance = () => null,
+            TestDispatch = async (_, methodName, _) =>
+            {
+                await Task.CompletedTask;
+                if (methodName == "FailingTest")
+                    throw new InvalidOperationException("Test intentionally failed");
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -294,7 +310,6 @@ public class ExecutionEngineTests
         XunitAssert.Equal(TestStatus.Failed, results[0].Status);
         XunitAssert.Equal("FailingTest", results[0].TestName);
         XunitAssert.Contains("Test intentionally failed", results[0].ErrorMessage);
-        XunitAssert.Equal("System.InvalidOperationException", results[0].ErrorType);
     }
 
     [XunitFact]
@@ -308,18 +323,17 @@ public class ExecutionEngineTests
             AssemblyName = "TestAssembly",
             TestMethods =
             [
-                new TestMethodMetadata.Fact
-                {
-                    MethodName = "AsyncTest",
-                    IsAsync = true,
-                    Body = async (ct) =>
-                    {
-                        await Task.Delay(50, ct); // Simulate async work
-                        asyncExecuted = true;
-                        // No exception = test passes
-                    },
-                },
+                new TestMethodMetadata.Fact { MethodName = "AsyncTest", IsAsync = true },
             ],
+            CreateInstance = () => null,
+            TestDispatch = async (_, methodName, _) =>
+            {
+                if (methodName == "AsyncTest")
+                {
+                    await Task.Delay(50); // Simulate async work
+                    asyncExecuted = true;
+                }
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -332,5 +346,138 @@ public class ExecutionEngineTests
         XunitAssert.Single(results);
         XunitAssert.Equal(TestStatus.Passed, results[0].Status);
         XunitAssert.True(results[0].Duration >= TimeSpan.FromMilliseconds(40)); // Account for timing variance
+    }
+
+    [XunitFact]
+    public async Task ExecuteTestsAsync_ClassesMode_RunsTestsWithinAClassSequentially()
+    {
+        // Arrange: tests in the same class share a dispatch that flags any concurrent overlap
+        var running = 0;
+        var overlapDetected = false;
+
+        var testMetadata = new TestClassMetadata
+        {
+            ClassName = "SequentialWithinClass",
+            AssemblyName = "TestAssembly",
+            TestMethods =
+            [
+                new TestMethodMetadata.Fact { MethodName = "T1" },
+                new TestMethodMetadata.Fact { MethodName = "T2" },
+                new TestMethodMetadata.Fact { MethodName = "T3" },
+            ],
+            CreateInstance = () => null,
+            TestDispatch = async (_, _, _) =>
+            {
+                if (Interlocked.Increment(ref running) > 1)
+                    overlapDetected = true;
+                await Task.Delay(30);
+                Interlocked.Decrement(ref running);
+            },
+        };
+
+        var options = new TestExecutionOptions
+        {
+            Mode = ParallelMode.Classes,
+            MaxDegreeOfParallelism = 4,
+        };
+
+        // Act
+        var results = await TestExecutionEngine.ExecuteTestsAsync([testMetadata], options);
+
+        // Assert
+        XunitAssert.Equal(3, results.Length);
+        XunitAssert.False(
+            overlapDetected,
+            "Tests within a single class must not run concurrently in Classes mode"
+        );
+    }
+
+    [XunitFact]
+    public async Task ExecuteTestsAsync_ClassesMode_RunsDifferentClassesInParallel()
+    {
+        // Arrange: each class's test rendezvouses with the other; this only
+        // completes if both classes are executing concurrently.
+        var classAStarted = new TaskCompletionSource();
+        var classBStarted = new TaskCompletionSource();
+
+        var classA = new TestClassMetadata
+        {
+            ClassName = "ClassA",
+            AssemblyName = "TestAssembly",
+            TestMethods = [new TestMethodMetadata.Fact { MethodName = "A1" }],
+            CreateInstance = () => null,
+            TestDispatch = async (_, _, _) =>
+            {
+                classAStarted.SetResult();
+                await classBStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            },
+        };
+
+        var classB = new TestClassMetadata
+        {
+            ClassName = "ClassB",
+            AssemblyName = "TestAssembly",
+            TestMethods = [new TestMethodMetadata.Fact { MethodName = "B1" }],
+            CreateInstance = () => null,
+            TestDispatch = async (_, _, _) =>
+            {
+                classBStarted.SetResult();
+                await classAStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            },
+        };
+
+        var options = new TestExecutionOptions
+        {
+            Mode = ParallelMode.Classes,
+            MaxDegreeOfParallelism = 2,
+        };
+
+        // Act
+        var results = await TestExecutionEngine.ExecuteTestsAsync([classA, classB], options);
+
+        // Assert: both pass, proving they ran concurrently (sequential execution would time out)
+        XunitAssert.Equal(2, results.Length);
+        XunitAssert.All(results, r => XunitAssert.Equal(TestStatus.Passed, r.Status));
+    }
+
+    [XunitFact]
+    public async Task ExecuteTestsAsync_RandomlyPermutesTestsAcrossRuns()
+    {
+        async Task<string> RunAndCaptureOrder()
+        {
+            var order = new System.Collections.Generic.List<string>();
+            var gate = new object();
+
+            var metadata = new TestClassMetadata
+            {
+                ClassName = "PermuteClass",
+                AssemblyName = "TestAssembly",
+                TestMethods = Enumerable
+                    .Range(0, 25)
+                    .Select(i => (TestMethodMetadata)new TestMethodMetadata.Fact { MethodName = $"T{i:D2}" })
+                    .ToArray(),
+                CreateInstance = () => null,
+                TestDispatch = (_, methodName, _) =>
+                {
+                    lock (gate)
+                    {
+                        order.Add(methodName);
+                    }
+                    return Task.CompletedTask;
+                },
+            };
+
+            // Sequential mode so execution order reflects the (shuffled) collection order.
+            var options = new TestExecutionOptions { Mode = ParallelMode.None };
+            await TestExecutionEngine.ExecuteTestsAsync([metadata], options);
+
+            return string.Join(",", order);
+        }
+
+        var run1 = await RunAndCaptureOrder();
+        var run2 = await RunAndCaptureOrder();
+
+        // With 25 tests, two independent shuffles producing the same order is astronomically unlikely.
+        XunitAssert.NotEqual(run1, run2);
     }
 }

--- a/test/UXUnit.Runtime.Tests/ParameterizedTestExecutionTests.cs
+++ b/test/UXUnit.Runtime.Tests/ParameterizedTestExecutionTests.cs
@@ -22,7 +22,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Theory
@@ -62,7 +61,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Theory
@@ -104,7 +102,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Theory
@@ -145,7 +142,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Theory
@@ -189,7 +185,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Theory
@@ -225,7 +220,6 @@ public class ParameterizedTestExecutionTests
         var testMetadata = new TestClassMetadata
         {
             ClassName = "SimpleTestClass",
-            AssemblyName = "TestAssembly",
             TestMethods =
             [
                 new TestMethodMetadata.Fact { MethodName = "SimpleTest" },

--- a/test/UXUnit.Runtime.Tests/ParameterizedTestExecutionTests.cs
+++ b/test/UXUnit.Runtime.Tests/ParameterizedTestExecutionTests.cs
@@ -18,7 +18,6 @@ public class ParameterizedTestExecutionTests
     {
         // Arrange: A theory-style test with one test case
         var executionCount = 0;
-        var capturedArgs = new object?[0];
 
         var testMetadata = new TestClassMetadata
         {
@@ -29,14 +28,18 @@ public class ParameterizedTestExecutionTests
                 new TestMethodMetadata.Theory
                 {
                     MethodName = "AddTest",
-                    TestCases = [new TestCaseMetadata { Arguments = [2, 3, 5] }],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        executionCount++;
-                        await Task.CompletedTask;
-                    },
+                    TestCases =
+                    [
+                        new TestCaseInfo { Arguments = (2, 3, 5), DisplayName = "2 + 3 = 5" },
+                    ],
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) =>
+            {
+                executionCount++;
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -67,17 +70,18 @@ public class ParameterizedTestExecutionTests
                     MethodName = "AddTest",
                     TestCases =
                     [
-                        new TestCaseMetadata { Arguments = [1, 2, 3] },
-                        new TestCaseMetadata { Arguments = [5, 7, 12] },
-                        new TestCaseMetadata { Arguments = [-1, 1, 0] },
+                        new TestCaseInfo { Arguments = (1, 2, 3), DisplayName = "1 + 2 = 3" },
+                        new TestCaseInfo { Arguments = (5, 7, 12), DisplayName = "5 + 7 = 12" },
+                        new TestCaseInfo { Arguments = (-1, 1, 0), DisplayName = "-1 + 1 = 0" },
                     ],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        executionCount++;
-                        await Task.CompletedTask;
-                    },
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) =>
+            {
+                executionCount++;
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -94,8 +98,8 @@ public class ParameterizedTestExecutionTests
     [XunitFact]
     public async Task ExecuteTestsAsync_WithTestCaseArguments_PassesArgumentsToDelegate()
     {
-        // Arrange: Test that verifies arguments are passed correctly
-        var capturedArguments = new System.Collections.Generic.List<object?[]>();
+        // Arrange: Test that verifies arguments are passed to the dispatch delegate
+        var capturedArguments = new System.Collections.Generic.List<object?>();
 
         var testMetadata = new TestClassMetadata
         {
@@ -108,17 +112,17 @@ public class ParameterizedTestExecutionTests
                     MethodName = "AddTest",
                     TestCases =
                     [
-                        new TestCaseMetadata { Arguments = [2, 3, 5] },
-                        new TestCaseMetadata { Arguments = [10, 20, 30] },
+                        new TestCaseInfo { Arguments = (2, 3, 5), DisplayName = "2 + 3 = 5" },
+                        new TestCaseInfo { Arguments = (10, 20, 30), DisplayName = "10 + 20 = 30" },
                     ],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        // In the real implementation, the delegate would receive arguments
-                        // For now, we just verify execution happens
-                        await Task.CompletedTask;
-                    },
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, theoryArgs) =>
+            {
+                capturedArguments.Add(theoryArgs);
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -128,6 +132,8 @@ public class ParameterizedTestExecutionTests
 
         // Assert
         XunitAssert.Equal(2, results.Length);
+        XunitAssert.Equal(2, capturedArguments.Count);
+        XunitAssert.All(capturedArguments, a => XunitAssert.NotNull(a));
     }
 
     [XunitFact]
@@ -147,21 +153,22 @@ public class ParameterizedTestExecutionTests
                     MethodName = "AddTest",
                     TestCases =
                     [
-                        new TestCaseMetadata { Arguments = [1, 2, 3] },
-                        new TestCaseMetadata { Arguments = [5, 5, 11] }, // This one will "fail"
-                        new TestCaseMetadata { Arguments = [0, 0, 0] },
+                        new TestCaseInfo { Arguments = (1, 2, 3), DisplayName = "case 1" },
+                        new TestCaseInfo { Arguments = (5, 5, 11), DisplayName = "case 2" },
+                        new TestCaseInfo { Arguments = (0, 0, 0), DisplayName = "case 3" },
                     ],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        executionCount++;
-                        if (executionCount == 2)
-                        {
-                            throw new InvalidOperationException("Test case failed");
-                        }
-                        await Task.CompletedTask;
-                    },
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) =>
+            {
+                executionCount++;
+                if (executionCount == 2)
+                {
+                    throw new InvalidOperationException("Test case failed");
+                }
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;
@@ -173,52 +180,6 @@ public class ParameterizedTestExecutionTests
         XunitAssert.Equal(3, results.Length);
         XunitAssert.Equal(2, results.Count(r => r.Status == TestStatus.Passed));
         XunitAssert.Single(results, r => r.Status == TestStatus.Failed);
-    }
-
-    [XunitFact]
-    public async Task ExecuteTestsAsync_WithSkippedTestCase_SkipsThatCase()
-    {
-        // Arrange: Theory test with a skipped case
-        var testMetadata = new TestClassMetadata
-        {
-            ClassName = "TheoryTestClass",
-            AssemblyName = "TestAssembly",
-            TestMethods =
-            [
-                new TestMethodMetadata.Theory
-                {
-                    MethodName = "AddTest",
-                    TestCases =
-                    [
-                        new TestCaseMetadata { Arguments = [1, 2, 3] },
-                        new TestCaseMetadata
-                        {
-                            Arguments = [5, 5, 10],
-                            Skip = true,
-                            SkipReason = "Known issue",
-                        },
-                        new TestCaseMetadata { Arguments = [0, 0, 0] },
-                    ],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        await Task.CompletedTask;
-                    },
-                },
-            ],
-        };
-
-        var options = TestExecutionOptions.Default;
-
-        // Act
-        var results = await TestExecutionEngine.ExecuteTestsAsync([testMetadata], options);
-
-        // Assert
-        XunitAssert.Equal(3, results.Length);
-        XunitAssert.Equal(2, results.Count(r => r.Status == TestStatus.Passed));
-        XunitAssert.Single(results, r => r.Status == TestStatus.Skipped);
-
-        var skippedResult = results.Single(r => r.Status == TestStatus.Skipped);
-        XunitAssert.Equal("Known issue", skippedResult.SkipReason);
     }
 
     [XunitFact]
@@ -236,19 +197,13 @@ public class ParameterizedTestExecutionTests
                     MethodName = "AddTest",
                     TestCases =
                     [
-                        new TestCaseMetadata { Arguments = [2, 3, 5], DisplayName = "2 + 3 = 5" },
-                        new TestCaseMetadata
-                        {
-                            Arguments = [10, 20, 30],
-                            DisplayName = "10 + 20 = 30",
-                        },
+                        new TestCaseInfo { Arguments = (2, 3, 5), DisplayName = "2 + 3 = 5" },
+                        new TestCaseInfo { Arguments = (10, 20, 30), DisplayName = "10 + 20 = 30" },
                     ],
-                    ParameterizedBody = async (args, ct) =>
-                    {
-                        await Task.CompletedTask;
-                    },
                 },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) => Task.CompletedTask,
         };
 
         var options = TestExecutionOptions.Default;
@@ -258,15 +213,13 @@ public class ParameterizedTestExecutionTests
 
         // Assert
         XunitAssert.Equal(2, results.Length);
-        // Note: The actual implementation should include display names in TestResult
-        // This is a placeholder assertion until that's implemented
         XunitAssert.All(results, r => XunitAssert.NotNull(r.TestName));
     }
 
     [XunitFact]
     public async Task ExecuteTestsAsync_WithNoTestCases_ExecutesMethodOnce()
     {
-        // Arrange: A method with no TestCases should execute once (like a Fact)
+        // Arrange: A Fact should execute once
         var executionCount = 0;
 
         var testMetadata = new TestClassMetadata
@@ -275,16 +228,14 @@ public class ParameterizedTestExecutionTests
             AssemblyName = "TestAssembly",
             TestMethods =
             [
-                new TestMethodMetadata.Fact
-                {
-                    MethodName = "SimpleTest",
-                    Body = async (ct) =>
-                    {
-                        executionCount++;
-                        await Task.CompletedTask;
-                    },
-                },
+                new TestMethodMetadata.Fact { MethodName = "SimpleTest" },
             ],
+            CreateInstance = () => null,
+            TestDispatch = (_, _, _) =>
+            {
+                executionCount++;
+                return Task.CompletedTask;
+            },
         };
 
         var options = TestExecutionOptions.Default;


### PR DESCRIPTION
Refocuses uxunit as a small, simple, source-generated replacement for the core of xUnit, and aligns the runtime, generator, and docs around that goal.

## Execution model
- Add `ParallelMode` (`None`/`Classes`/`Tests`) with **`Tests` as the default**, so every test runs in parallel by default.
- **Randomly permute tests each run** (Fisher-Yates) to surface accidental ordering dependencies, regardless of mode.

## Dispatch-based metadata model
- Replace per-method execution delegates (`Body`/`ParameterizedBody`) with a per-class `CreateInstance` factory + `TestDispatch` delegate; the engine creates the instance and dispatches by method name.
- `TestCaseInfo.Arguments` is now `object?`: a single argument is boxed directly, multiple arguments use a `ValueTuple`, and dispatch casts straight to the concrete type (no per-element `ITuple` unboxing).
- Fix theory collection to emit one descriptor per method (previously N executions).
- Dispose `IDisposable` test instances in a `finally` in the engine.
- Restore xUnit-style per-case naming: `MethodName(arg: value, ...)`.

## Generator
- Emit `CreateInstance` + `TestDispatch` + `TestCaseInfo` for the new model.
- Update Verify snapshots accordingly.

## Docs
- Remove aspirational attributes (`[TestClass]`/`[ClassSetup]`/`[Parallel]`) and retune positioning; reference `xunit.v3.assert` rather than a bespoke assertion package.

## Testing
- Migrate the hand-written runtime tests to the new model.
- Build is clean; **all 25 tests pass** (runtime unit tests, generator snapshot tests, and the xUnit-vs-UXUnit TRX compatibility E2E), stable across repeated runs.

## Notes
- The known gaps remain tracked as open issues: test discovery (#18), filters (#19), diagnostics (#22), and `[MemberData]` (#23). The engine now disposes in a `finally`, which likely resolves #20.