### PR TITLE
Use explicit versioning and fix generator test NuGet.config resolution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,7 @@
 name: Publish
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to publish (e.g. 1.2.3). Leave blank to derive from the git tag.'
-        required: false
-        default: ''
 
 jobs:
   publish:
@@ -26,16 +18,12 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
-      - name: Determine version
+      - name: Read version
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-          else
-            VERSION="${GITHUB_REF_NAME#v}"
-          fi
+          VERSION=$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' Directory.Build.props | head -n1 | tr -d '[:space:]')
           if [ -z "$VERSION" ]; then
-            echo "Could not determine a version to publish." >&2
+            echo "Could not read <Version> from Directory.Build.props." >&2
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -44,16 +32,16 @@ jobs:
       - name: Build
         run: >-
           dotnet build NXTest.sln
-          -c Release -p:Version=${{ steps.version.outputs.version }} -p:ContinuousIntegrationBuild=true
+          -c Release -p:ContinuousIntegrationBuild=true
 
       - name: Run tests
-        run: dotnet test NXTest.sln -c Release -p:Version=${{ steps.version.outputs.version }} --no-build
+        run: dotnet test NXTest.sln -c Release --no-build
 
       - name: Pack
         run: |
           for proj in Core Runtime Generators; do
             dotnet pack "src/NXTest.$proj/NXTest.$proj.csproj" \
-              -c Release -p:Version=${{ steps.version.outputs.version }} --no-build
+              -c Release --no-build
           done
 
       - name: NuGet login (OIDC -> short-lived API key)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,9 +5,9 @@
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
-  <!-- Shared NuGet package metadata. Version can be overridden from CI via -p:Version=. -->
+  <!-- Shared NuGet package metadata. Update <Version> here to release a new version. -->
   <PropertyGroup>
-    <Version Condition="'$(Version)' == ''">0.1.1</Version>
+    <Version>0.1.1</Version>
     <Authors>NXTest Team</Authors>
     <Copyright>© NXTest Team</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/test/NXTest.Generators.Tests/Config.cs
+++ b/test/NXTest.Generators.Tests/Config.cs
@@ -1,5 +1,5 @@
+using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Testing;
 
 namespace NXTest.Generators.Tests;
@@ -12,10 +12,6 @@ internal static class Config
             new PackageIdentity("Microsoft.NETCore.App.Ref", "10.0.0"),
             Path.Combine("ref", "net10.0"))
         .WithNuGetConfigFilePath(Path.Combine(
-            GetDirectoryPath(),
-            "..",
-            "..",
+            AppContext.BaseDirectory,
             "NuGet.config"));
-
-    private static string GetDirectoryPath([CallerFilePath]string path = "") => Path.GetDirectoryName(path)!;
 }

--- a/test/NXTest.Generators.Tests/NXTest.Generators.Tests.csproj
+++ b/test/NXTest.Generators.Tests/NXTest.Generators.Tests.csproj
@@ -7,6 +7,10 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <GenerateTestingPlatformEntryPoint>true</GenerateTestingPlatformEntryPoint>
+    <!-- This test project resolves files (NuGet.config, Verify snapshots) via source
+         paths at runtime, so it must not have them rewritten to /_/ by deterministic
+         CI builds. The project is not packed, so this has no effect on shipped output. -->
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
   <ItemGroup>
@@ -31,6 +35,10 @@
       Include="../../src/NXTest.Generators/NXTest.Generators.csproj"
       OutputItemType="Analyzer"
     />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../NuGet.config" Link="NuGet.config" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <!-- Run via the Microsoft.Testing.Platform auto-generated entry point. -->


### PR DESCRIPTION
## Summary
Switches release versioning from git tags to an explicit version, and fixes generator test failures under deterministic CI builds. Rebased onto latest `main`.

### Explicit versioning
- `publish.yml` no longer derives the version from `v*.*.*` git tags. It reads the explicit `<Version>` from `Directory.Build.props` and runs on manual `workflow_dispatch` only.
- `Directory.Build.props` is the single source of truth: `<Version>` is unconditional (no longer overridden via `-p:Version=`), set to **0.1.1** (patch after the published `0.1.0`).

### Fix deterministic-build test failures
Under `-p:ContinuousIntegrationBuild=true` (used by the publish workflow), source paths are rewritten to `/_/...`, so `NXTest.Generators.Tests` file lookups failedb  for both `NuGet.config` and Verify snapshots. Fixes:
- Resolve `NuGet.config` from `AppContext.BaseDirectory` and copy it to the test output directory.
- Disable `DeterministicSourcePaths` for this (non-packed) test project so Verify snapshot resolution via `[CallerFilePath]` works. This was pre-existing on `main` and would have broken the publish workflow.

## Testing
- `dotnet test NXTest.sln -c Release -p:ContinuousIntegrationBuild=true` -> **28/28 passed**.
- Verified `dotnet pack` produces `NXTest.Core.0.1.1.nupkg`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
