### PR TITLE
Implement test discovery (DiscoverTestExecutionRequest)

### DIFF
--- a/src/NXTest.Runtime/TestFramework.cs
+++ b/src/NXTest.Runtime/TestFramework.cs
@@ -10,6 +10,7 @@ using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions.Messages;
 using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Requests;
+using Microsoft.Testing.Platform.TestHost;
 
 namespace NXTest.Runtime;
 
@@ -107,7 +108,15 @@ public sealed class TestFramework : ITestFramework, IDataProducer
     {
         if (context.Request is DiscoverTestExecutionRequest)
         {
-            throw new System.NotImplementedException();
+            try
+            {
+                // Enumerate all tests and publish them as discovered nodes (no execution).
+                await DiscoverTestsAsync(context);
+            }
+            finally
+            {
+                context.Complete();
+            }
         }
         else if (context.Request is RunTestExecutionRequest)
         {
@@ -122,6 +131,81 @@ public sealed class TestFramework : ITestFramework, IDataProducer
                 context.Complete();
             }
         }
+    }
+
+    private async Task DiscoverTestsAsync(ExecuteRequestContext context)
+    {
+        var sessionUid = context.Request.Session.SessionUid;
+
+        // Walk test classes in parallel; the message bus accepts concurrent publishes (the run
+        // path already relies on this). Discovery has no ordering dependencies, so the run-time
+        // shuffle is intentionally skipped here.
+        await Parallel.ForEachAsync(
+            _testClasses,
+            new ParallelOptions
+            {
+                MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism,
+                CancellationToken = context.CancellationToken,
+            },
+            async (testClass, ct) =>
+            {
+                foreach (var method in testClass.TestMethods)
+                {
+                    if (ct.IsCancellationRequested)
+                        return;
+
+                    // A skipped test (fact or theory) runs as a single node named after the
+                    // method, so discovery must mirror that to keep Uids correlated with a run.
+                    if (method.Skip)
+                    {
+                        await PublishDiscoveredNodeAsync(
+                            context, sessionUid, testClass.ClassName, $"{testClass.ClassName}.{method.MethodName}");
+                        continue;
+                    }
+
+                    switch (method)
+                    {
+                        case TestMethodMetadata.Theory theory:
+                            foreach (var testCase in theory.TestCases)
+                            {
+                                await PublishDiscoveredNodeAsync(
+                                    context,
+                                    sessionUid,
+                                    testClass.ClassName,
+                                    $"{testClass.ClassName}.{theory.MethodName}({testCase.DisplayName})"
+                                );
+                            }
+                            break;
+
+                        default:
+                            await PublishDiscoveredNodeAsync(
+                                context, sessionUid, testClass.ClassName, $"{testClass.ClassName}.{method.MethodName}");
+                            break;
+                    }
+                }
+            }
+        );
+    }
+
+    // Publishes a single discovered TestNode. The fully-qualified name matches what a run
+    // produces as TestNode Uid/DisplayName so discovered nodes correlate with executed ones.
+    private async Task PublishDiscoveredNodeAsync(
+        ExecuteRequestContext context,
+        SessionUid sessionUid,
+        string className,
+        string fqn
+    )
+    {
+        var testNode = new TestNode()
+        {
+            Uid = fqn,
+            DisplayName = fqn,
+            Properties = new PropertyBag(
+                new TrxFullyQualifiedTypeNameProperty(className),
+                DiscoveredTestNodeStateProperty.CachedInstance
+            )
+        };
+        await context.MessageBus.PublishAsync(this, new TestNodeUpdateMessage(sessionUid, testNode));
     }
 
     private async Task ExecuteTestsAsync(ExecuteRequestContext context)


### PR DESCRIPTION
## Summary

Implements test discovery for the MTP `ITestFramework`. Previously `DiscoverTestExecutionRequest` threw `NotImplementedException`, so IDE Test Explorers and `dotnet test --list-tests` could not enumerate testsb  only a full run worked.

`ExecuteRequestAsync` now handles `DiscoverTestExecutionRequest` by walking the test metadata and publishing a discovered `TestNode` per test.

## Details

- **Correlated identities**b  discovered node `Uid`/`DisplayName` use the exact same fully-qualified name the run path produces (`{ClassName}.{TestName}`): theory cases are expanded to `Method(caseDisplayName)`, and skipped tests collapse to a single method-named node (mirroring run behavior). This ensures tooling correlates discovered and executed nodes.
- **Discovery state**b  nodes carry `DiscoveredTestNodeStateProperty` (no execution) plus the same `TrxFullyQualifiedTypeNameProperty` attached to run nodes.
- **Parallel + streaming**b  test classes are walked in parallel (respecting `MaxDegreeOfParallelism`) and each node is published as it is visited. The run-time shuffle is intentionally skipped since discovery has no ordering dependencies.

## Testing

- `dotnet test --list-tests` on the compat asset enumerates all 13 tests; a normal run produces identical FQNs (13), confirming correlation.
- Existing 19 runtime tests pass; clean build.

Fixes #18