### PR TITLE
Package generator as analyzer

### DIFF
--- a/src/NXTest.Generators/NXTest.Generators.csproj
+++ b/src/NXTest.Generators/NXTest.Generators.csproj
@@ -10,17 +10,22 @@
     <Title>NXTest Source Generators</Title>
     <Description>Source generators for the NXTest testing framework</Description>
     <PackageTags>testing;unit-testing;source-generator;dotnet</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DebugType>embedded</DebugType>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);RS1035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-    <PackageReference Include="StaticCS.IndentingBuilder" />
+    <PackageReference Include="StaticCS.IndentingBuilder" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- place the source generator under `analyzers/dotnet/cs` instead of `lib`
- embed PDBs and omit the separate symbol package
- prevent generator-only dependencies from flowing to consumers
- construct typed `ValueTuple` instances for multi-argument `InlineData`, allowing null elements

## Testing
- `dotnet build test/NXTest.Generators.Tests/NXTest.Generators.Tests.csproj --no-restore`
- `dotnet artifacts/bin/NXTest.Generators.Tests/debug/NXTest.Generators.Tests.dll`
- `dotnet pack src/NXTest.Generators/NXTest.Generators.csproj --configuration Release --no-restore`