### PR TITLE
Handle null values in inline theory data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!-- Shared NuGet package metadata. Update <Version> here to release a new version. -->
   <PropertyGroup>
-    <Version>0.1.2</Version>
+    <Version>0.1.4</Version>
     <Authors>NXTest Team</Authors>
     <Copyright>© NXTest Team</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/NXTest.Generators/NXTest.Generators.csproj
+++ b/src/NXTest.Generators/NXTest.Generators.csproj
@@ -10,17 +10,22 @@
     <Title>NXTest Source Generators</Title>
     <Description>Source generators for the NXTest testing framework</Description>
     <PackageTags>testing;unit-testing;source-generator;dotnet</PackageTags>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DebugType>embedded</DebugType>
+    <IncludeSymbols>false</IncludeSymbols>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <NoWarn>$(NoWarn);RS1035</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
-    <PackageReference Include="StaticCS.IndentingBuilder" />
+    <PackageReference Include="StaticCS.IndentingBuilder" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/NXTest.Generators/TestGenerator.cs
+++ b/src/NXTest.Generators/TestGenerator.cs
@@ -347,12 +347,12 @@ public sealed class TestGenerator : IIncrementalGenerator
             builder.Indent();
 
             var args = testCase.Arguments.Select(FormatConstantValue).ToList();
-            // 1 arg: box the value directly. 2+ args: tuple literal. 0 args: null.
+            // 1 arg: box the value directly. 2+ args: construct a typed tuple. 0 args: null.
             var arguments = args.Count switch
             {
                 0 => "null",
                 1 => args[0],
-                _ => $"({string.Join(", ", args)})",
+                _ => $"new {BuildValueTupleType(parameters)}({string.Join(", ", args)})",
             };
             builder.AppendLine($"Arguments = {arguments},");
 

--- a/src/NXTest.Generators/TestGenerator.cs
+++ b/src/NXTest.Generators/TestGenerator.cs
@@ -299,8 +299,17 @@ public sealed class TestGenerator : IIncrementalGenerator
 
     private static string BuildValueTupleType(ImmutableArray<IParameterSymbol> parameters)
     {
-        var types = parameters.Select(p => p.Type.ToDisplayString());
-        return $"global::System.ValueTuple<{string.Join(", ", types)}>";
+        return $"global::System.ValueTuple<{BuildTupleElementTypes(parameters)}>";
+    }
+
+    private static string BuildTupleType(ImmutableArray<IParameterSymbol> parameters)
+    {
+        return $"({BuildTupleElementTypes(parameters)})";
+    }
+
+    private static string BuildTupleElementTypes(ImmutableArray<IParameterSymbol> parameters)
+    {
+        return string.Join(", ", parameters.Select(p => p.Type.ToDisplayString()));
     }
 
     private static void GenerateFactMetadata(
@@ -347,12 +356,12 @@ public sealed class TestGenerator : IIncrementalGenerator
             builder.Indent();
 
             var args = testCase.Arguments.Select(FormatConstantValue).ToList();
-            // 1 arg: box the value directly. 2+ args: construct a typed tuple. 0 args: null.
+            // 1 arg: box the value directly. 2+ args: cast to a typed tuple. 0 args: null.
             var arguments = args.Count switch
             {
                 0 => "null",
                 1 => args[0],
-                _ => $"new {BuildValueTupleType(parameters)}({string.Join(", ", args)})",
+                _ => $"({BuildTupleType(parameters)})({string.Join(", ", args)})",
             };
             builder.AppendLine($"Arguments = {arguments},");
 

--- a/test/NXTest.Generators.Tests/BasicGenerationTests.cs
+++ b/test/NXTest.Generators.Tests/BasicGenerationTests.cs
@@ -45,6 +45,44 @@ public class MathTests
     }
 
     [Fact]
+    public async Task GeneratesCompilableMetadataForMultiArgumentInlineDataWithNull()
+    {
+        var source = """
+using NXTest;
+
+public class NullableTheoryTests
+{
+    [Theory]
+    [InlineData(null, "bob@example.com", 2)]
+    public void SendsEmail(string? displayName, string email, int retryCount)
+    {
+    }
+}
+""";
+        var compilation = await TestHelpers.CreateCompilation(source);
+        var driver = TestHelpers.RunGenerator(compilation);
+        var result = driver.GetRunResult();
+        var generatedSource = result.GeneratedTrees
+            .Single(tree => tree.FilePath.EndsWith("NullableTheoryTests_Metadata.g.cs"))
+            .ToString();
+        var generatedCompilation = compilation.AddSyntaxTrees(result.GeneratedTrees);
+        var compilationErrors = generatedCompilation.GetDiagnostics()
+            .Where(d => d.Severity == Microsoft.CodeAnalysis.DiagnosticSeverity.Error)
+            .ToList();
+
+        if (!generatedSource.Contains(
+                "Arguments = new global::System.ValueTuple<string?, string, int>(null, \"bob@example.com\", 2),"))
+        {
+            throw new System.InvalidOperationException("Generated metadata did not construct a typed ValueTuple.");
+        }
+
+        if (compilationErrors.Count != 0)
+        {
+            throw new System.InvalidOperationException("Generated metadata did not compile.");
+        }
+    }
+
+    [Fact]
     public Task GeneratesMetadataForMultipleTestMethods()
     {
         var source = """

--- a/test/NXTest.Generators.Tests/BasicGenerationTests.cs
+++ b/test/NXTest.Generators.Tests/BasicGenerationTests.cs
@@ -71,9 +71,9 @@ public class NullableTheoryTests
             .ToList();
 
         if (!generatedSource.Contains(
-                "Arguments = new global::System.ValueTuple<string?, string, int>(null, \"bob@example.com\", 2),"))
+                "Arguments = ((string?, string, int))(null, \"bob@example.com\", 2),"))
         {
-            throw new System.InvalidOperationException("Generated metadata did not construct a typed ValueTuple.");
+            throw new System.InvalidOperationException("Generated metadata did not cast to a typed tuple.");
         }
 
         if (compilationErrors.Count != 0)

--- a/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForStaticTheoryMethod#StaticTheoryClass_Metadata.g.verified.cs
+++ b/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForStaticTheoryMethod#StaticTheoryClass_Metadata.g.verified.cs
@@ -44,12 +44,12 @@ namespace NXTest.Generated
                         {
                             new TestCaseInfo
                             {
-                                Arguments = new global::System.ValueTuple<int, int, int>(1, 2, 3),
+                                Arguments = ((int, int, int))(1, 2, 3),
                                 DisplayName = "a: 1, b: 2, sum: 3",
                             },
                             new TestCaseInfo
                             {
-                                Arguments = new global::System.ValueTuple<int, int, int>(5, 7, 12),
+                                Arguments = ((int, int, int))(5, 7, 12),
                                 DisplayName = "a: 5, b: 7, sum: 12",
                             },
                         },

--- a/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForStaticTheoryMethod#StaticTheoryClass_Metadata.g.verified.cs
+++ b/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForStaticTheoryMethod#StaticTheoryClass_Metadata.g.verified.cs
@@ -44,12 +44,12 @@ namespace NXTest.Generated
                         {
                             new TestCaseInfo
                             {
-                                Arguments = (1, 2, 3),
+                                Arguments = new global::System.ValueTuple<int, int, int>(1, 2, 3),
                                 DisplayName = "a: 1, b: 2, sum: 3",
                             },
                             new TestCaseInfo
                             {
-                                Arguments = (5, 7, 12),
+                                Arguments = new global::System.ValueTuple<int, int, int>(5, 7, 12),
                                 DisplayName = "a: 5, b: 7, sum: 12",
                             },
                         },

--- a/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
+++ b/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
@@ -44,12 +44,12 @@ namespace NXTest.Generated
                         {
                             new TestCaseInfo
                             {
-                                Arguments = new global::System.ValueTuple<int, int, int>(1, 2, 3),
+                                Arguments = ((int, int, int))(1, 2, 3),
                                 DisplayName = "a: 1, b: 2, sum: 3",
                             },
                             new TestCaseInfo
                             {
-                                Arguments = new global::System.ValueTuple<int, int, int>(5, 7, 12),
+                                Arguments = ((int, int, int))(5, 7, 12),
                                 DisplayName = "a: 5, b: 7, sum: 12",
                             },
                         },

--- a/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
+++ b/test/NXTest.Generators.Tests/Snapshots/BasicGenerationTests.GeneratesMetadataForTheoryWithInlineData#MathTests_Metadata.g.verified.cs
@@ -44,12 +44,12 @@ namespace NXTest.Generated
                         {
                             new TestCaseInfo
                             {
-                                Arguments = (1, 2, 3),
+                                Arguments = new global::System.ValueTuple<int, int, int>(1, 2, 3),
                                 DisplayName = "a: 1, b: 2, sum: 3",
                             },
                             new TestCaseInfo
                             {
-                                Arguments = (5, 7, 12),
+                                Arguments = new global::System.ValueTuple<int, int, int>(5, 7, 12),
                                 DisplayName = "a: 5, b: 7, sum: 12",
                             },
                         },


### PR DESCRIPTION
## Summary
- cast multi-argument `InlineData` tuple literals to their parameter tuple type
- allow null elements to bind to nullable parameter types
- add regression coverage that compiles generated metadata for null inline data
- bump package version to `0.1.4`

## Testing
- `dotnet build test/NXTest.Generators.Tests/NXTest.Generators.Tests.csproj --no-restore`
- `dotnet artifacts/bin/NXTest.Generators.Tests/debug/NXTest.Generators.Tests.dll`
- `dotnet pack src/NXTest.Generators/NXTest.Generators.csproj --configuration Release --no-restore`